### PR TITLE
chore: use UUID4 as request ID and pass from x-request-id header

### DIFF
--- a/pkg/logger/context.go
+++ b/pkg/logger/context.go
@@ -2,8 +2,8 @@ package logger
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
+
+	"github.com/google/uuid"
 )
 
 // WithRequestID adds a request ID to the context.
@@ -23,7 +23,6 @@ func WithOperation(ctx context.Context, operation string) context.Context {
 
 // GenerateRequestID generates a new request ID.
 func GenerateRequestID() string {
-	bytes := make([]byte, 8)
-	rand.Read(bytes) //nolint:errcheck
-	return hex.EncodeToString(bytes)
+	requestID := uuid.New()
+	return requestID.String()
 }

--- a/pkg/logger/middleware.go
+++ b/pkg/logger/middleware.go
@@ -13,8 +13,12 @@ func RequestLoggingMiddleware(logger *Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		start := time.Now()
 
-		// Generate request ID and add to context.
-		requestID := GenerateRequestID()
+		// Reuse the request ID from the request headers if present.
+		requestID := c.Request.Header.Get("x-request-id")
+		if requestID == "" {
+			// Generate request ID and add to context.
+			requestID = GenerateRequestID()
+		}
 		ctx := WithRequestID(c.Request.Context(), requestID)
 		ctx = WithOperation(ctx, "http_request")
 		c.Request = c.Request.WithContext(ctx)


### PR DESCRIPTION
The current deployment places the service behind an instance of an ingress proxy that automatically generates request IDs for all incoming requests in the form of a UUID4 and provides them in the `x-request-id` request header, so it makes sense to reuse the value of this header if present.

Also, the common practice is to use UUID4s for request IDs as implemented by that proxy, so if the header is not present, generate a new request ID as a UUID4 rather than an 8-byte sequence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The system now supports accepting a request ID from incoming HTTP request headers ("x-request-id"). If provided, this ID will be used; otherwise, a new one is generated.

* **Refactor**
  * Request IDs are now generated using standard UUIDs, improving consistency and uniqueness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->