### PR TITLE
feat: parse and log token usage for each proxied request

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -64,6 +64,12 @@ func main() {
 	logger := logger.New(loggerConfig)
 	log := logger.WithComponent("main")
 
+	log.Info("logger initialized",
+		slog.String("log_level", config.AppConfig.LogLevel),
+		slog.String("log_format", config.AppConfig.LogFormat),
+		slog.String("effective_level", loggerConfig.Level.String()),
+	)
+
 	// Set Gin mode
 	log.Info("setting gin mode", slog.String("mode", config.AppConfig.GinMode))
 	gin.SetMode(config.AppConfig.GinMode)
@@ -318,11 +324,11 @@ func setupRESTServer(input restServerInput) *gin.Engine {
 	proxyGroup := router.Group("/")
 	proxyGroup.Use(request_tracking.RequestTrackingMiddleware(input.requestTrackingService, input.logger))
 	{
-		proxyGroup.POST("/chat/completions", proxy.ProxyHandler(input.logger))
-		proxyGroup.POST("/embeddings", proxy.ProxyHandler(input.logger))
-		proxyGroup.POST("/audio/speech", proxy.ProxyHandler(input.logger))
-		proxyGroup.POST("/audio/transcriptions", proxy.ProxyHandler(input.logger))
-		proxyGroup.POST("/audio/translations", proxy.ProxyHandler(input.logger))
+		proxyGroup.POST("/chat/completions", proxy.ProxyHandler(input.logger, input.requestTrackingService))
+		proxyGroup.POST("/embeddings", proxy.ProxyHandler(input.logger, input.requestTrackingService))
+		proxyGroup.POST("/audio/speech", proxy.ProxyHandler(input.logger, input.requestTrackingService))
+		proxyGroup.POST("/audio/transcriptions", proxy.ProxyHandler(input.logger, input.requestTrackingService))
+		proxyGroup.POST("/audio/translations", proxy.ProxyHandler(input.logger, input.requestTrackingService))
 	}
 
 	return router

--- a/internal/proxy/handlers.go
+++ b/internal/proxy/handlers.go
@@ -1,7 +1,10 @@
 package proxy
 
 import (
+	"bufio"
 	"bytes"
+	"compress/gzip"
+	"context"
 	"io"
 	"log/slog"
 	"net/http"
@@ -10,20 +13,26 @@ import (
 	"strings"
 	"time"
 
+	"github.com/eternisai/enchanted-proxy/internal/auth"
 	"github.com/eternisai/enchanted-proxy/internal/config"
 	"github.com/eternisai/enchanted-proxy/internal/logger"
+	"github.com/eternisai/enchanted-proxy/internal/request_tracking"
 	"github.com/gin-gonic/gin"
 )
 
-func ProxyHandler(logger *logger.Logger) gin.HandlerFunc {
+func ProxyHandler(logger *logger.Logger, trackingService *request_tracking.Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		start := time.Now()
 		log := logger.WithContext(c.Request.Context()).WithComponent("proxy")
 
-		var requestBody []byte
-		var model string
+		var (
+			requestBody []byte
+			err         error
+			model       string
+		)
+
 		if c.Request.Body != nil {
-			requestBody, err := io.ReadAll(c.Request.Body)
+			requestBody, err = io.ReadAll(c.Request.Body)
 			if err != nil {
 				log.Error("failed to read request body", slog.String("error", err.Error()))
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read request body"})
@@ -88,14 +97,11 @@ func ProxyHandler(logger *logger.Logger) gin.HandlerFunc {
 			upstreamLatency := time.Since(start)
 			isStreaming := strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream")
 
-			log.Info("proxy response received",
-				slog.Int("status_code", resp.StatusCode),
-				slog.String("content_type", resp.Header.Get("Content-Type")),
-				slog.Bool("is_streaming", isStreaming),
-				slog.Duration("upstream_latency", upstreamLatency),
-				slog.String("response_id", resp.Header.Get("X-Request-ID")),
-			)
-			return nil
+			if isStreaming {
+				return handleStreamingResponse(resp, log, model, upstreamLatency, c, trackingService)
+			} else {
+				return handleNonStreamingResponse(resp, log, model, upstreamLatency, c, trackingService)
+			}
 		}
 
 		orig := proxy.Director
@@ -126,6 +132,183 @@ func ProxyHandler(logger *logger.Logger) gin.HandlerFunc {
 			return
 		default:
 			proxy.ServeHTTP(c.Writer, c.Request)
+		}
+	}
+}
+
+// handleStreamingResponse extracts token usage from streaming responses.
+func handleStreamingResponse(resp *http.Response, log *logger.Logger, model string, upstreamLatency time.Duration, c *gin.Context, trackingService *request_tracking.Service) error {
+	pr, pw := io.Pipe()
+	originalBody := resp.Body
+	resp.Body = pr
+
+	go func() {
+		defer pw.Close()           //nolint:errcheck
+		defer originalBody.Close() //nolint:errcheck
+
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error("panic in streaming response handler",
+					slog.Any("panic", r),
+					slog.String("target_url", resp.Request.URL.String()),
+					slog.String("provider", request_tracking.GetProviderFromBaseURL(c.GetHeader("X-BASE-URL"))),
+				)
+			}
+		}()
+
+		var reader io.Reader = originalBody
+
+		// Decompress gzipped responses if needed.
+		if strings.Contains(resp.Header.Get("Content-Encoding"), "gzip") {
+			gzReader, err := gzip.NewReader(originalBody)
+			if err != nil {
+				log.Error("failed to create gzip reader for streaming response", slog.String("error", err.Error()))
+				return
+			}
+			defer gzReader.Close() //nolint:errcheck
+			reader = gzReader
+			// Remove Content-Encoding header since we're decompressing.
+			// TODO: @pottekkat recompress the response body before sending it to the client.
+			resp.Header.Del("Content-Encoding")
+		}
+
+		scanner := bufio.NewScanner(reader)
+		var responseBodyBuilder strings.Builder
+		var tokenUsage *Usage
+
+		for scanner.Scan() {
+			line := scanner.Text()
+
+			// Pipe the line to the client immediately.
+			if _, err := pw.Write(append([]byte(line), '\n')); err != nil {
+				log.Error("failed to write to pipe", slog.String("error", err.Error()))
+				return
+			}
+
+			responseBodyBuilder.WriteString(line)
+			responseBodyBuilder.WriteByte('\n')
+
+			// Extract the token usage from second to last chunk which contains a usage field.
+			// See: https://openrouter.ai/docs/use-cases/usage-accounting#streaming-with-usage-information
+			if usage := extractTokenUsageFromSSELine(line); usage != nil {
+				tokenUsage = usage
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			log.Error("scanner error while processing SSE stream", slog.String("error", err.Error()))
+		}
+
+		responseBody := responseBodyBuilder.String()
+		logProxyResponse(log, resp, true, upstreamLatency, model, tokenUsage, []byte(responseBody), c.Request.Context())
+
+		logRequestToDatabase(c, trackingService, model, tokenUsage)
+	}()
+
+	// Remove Content-Length for chunked encoding.
+	resp.Header.Del("Content-Length")
+	return nil
+}
+
+// handleNonStreamingResponse extracts token usage from non-streaming responses.
+func handleNonStreamingResponse(resp *http.Response, log *logger.Logger, model string, upstreamLatency time.Duration, c *gin.Context, trackingService *request_tracking.Service) error {
+	var responseBody []byte
+	if resp.Body != nil {
+		responseBody, _ = io.ReadAll(resp.Body)
+		resp.Body = io.NopCloser(bytes.NewReader(responseBody))
+
+		if strings.Contains(resp.Header.Get("Content-Encoding"), "gzip") && len(responseBody) > 0 {
+			if gzReader, err := gzip.NewReader(bytes.NewReader(responseBody)); err == nil {
+				if decompressed, err := io.ReadAll(gzReader); err == nil {
+					responseBody = decompressed
+				}
+				defer gzReader.Close() //nolint:errcheck
+			}
+		}
+	}
+
+	var tokenUsage *Usage
+	if len(responseBody) > 0 {
+		tokenUsage = extractTokenUsage(responseBody)
+
+		if tokenUsage == nil {
+			log.Debug("No token usage found in response",
+				slog.Bool("is_streaming", false),
+				slog.Int("response_size", len(responseBody)),
+				slog.String("content_type", resp.Header.Get("Content-Type")),
+			)
+		}
+	}
+
+	logProxyResponse(log, resp, false, upstreamLatency, model, tokenUsage, responseBody, c.Request.Context())
+
+	logRequestToDatabase(c, trackingService, model, tokenUsage)
+
+	return nil
+}
+
+// logProxyResponse logs the final proxy response with consolidated token usage data.
+func logProxyResponse(log *logger.Logger, resp *http.Response, isStreaming bool, upstreamLatency time.Duration, model string, tokenUsage *Usage, responseBody []byte, ctx context.Context) {
+	responseLogArgs := []any{
+		slog.Int("status_code", resp.StatusCode),
+		slog.String("content_type", resp.Header.Get("Content-Type")),
+		slog.Bool("is_streaming", isStreaming),
+		slog.Duration("upstream_latency", upstreamLatency),
+		slog.String("response_id", resp.Header.Get("X-Request-ID")),
+	}
+
+	if tokenUsage != nil {
+		responseLogArgs = append(responseLogArgs,
+			slog.Int("prompt_tokens", tokenUsage.PromptTokens),
+			slog.Int("completion_tokens", tokenUsage.CompletionTokens),
+			slog.Int("total_tokens", tokenUsage.TotalTokens),
+			slog.String("model", model),
+		)
+	}
+
+	// Add response body to debug logs.
+	if log.Enabled(ctx, slog.LevelDebug) && len(responseBody) > 0 {
+		responseLogArgs = append(responseLogArgs, slog.String("response_body", logRequestBody(responseBody, 500)))
+	}
+
+	log.Info("proxy response received", responseLogArgs...)
+}
+
+// logRequestToDatabase logs a request to the database with token usage data.
+func logRequestToDatabase(c *gin.Context, trackingService *request_tracking.Service, model string, tokenUsage *Usage) {
+	userID, exists := auth.GetUserUUID(c)
+	if !exists {
+		return
+	}
+
+	baseURL := c.GetHeader("X-BASE-URL")
+	provider := request_tracking.GetProviderFromBaseURL(baseURL)
+	endpoint := c.Request.URL.Path
+
+	info := request_tracking.RequestInfo{
+		UserID:   userID,
+		Endpoint: endpoint,
+		Model:    model,
+		Provider: provider,
+	}
+
+	var tokenData *request_tracking.TokenUsage
+	if tokenUsage != nil {
+		tokenData = &request_tracking.TokenUsage{
+			PromptTokens:     tokenUsage.PromptTokens,
+			CompletionTokens: tokenUsage.CompletionTokens,
+			TotalTokens:      tokenUsage.TotalTokens,
+		}
+	}
+
+	if err := trackingService.LogRequestWithTokensAsync(c.Request.Context(), info, tokenData); err != nil {
+		if loggerValue := c.Value("logger"); loggerValue != nil {
+			if log, ok := loggerValue.(*logger.Logger); ok {
+				log.Error("failed to log request to database",
+					slog.String("user_id", userID),
+					slog.String("endpoint", endpoint),
+					slog.String("error", err.Error()))
+			}
 		}
 	}
 }

--- a/internal/proxy/utils.go
+++ b/internal/proxy/utils.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/eternisai/enchanted-proxy/internal/config"
 )
@@ -51,5 +52,79 @@ func getAPIKey(baseURL string, config *config.Config) string {
 		return config.TinfoilAPIKey
 	default:
 		return ""
+	}
+}
+
+// Usage represents token usage from OpenAI/OpenRouter APIs.
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// CompletionResponse represents a non-streamed completion response.
+type CompletionResponse struct {
+	Usage *Usage `json:"usage"`
+}
+
+// extractTokenUsage extracts token usage from non-streamed OpenAI/OpenRouter response.
+func extractTokenUsage(responseBody []byte) *Usage {
+	if len(responseBody) == 0 {
+		return nil
+	}
+
+	var parsed CompletionResponse
+	if err := json.Unmarshal(responseBody, &parsed); err != nil {
+		return nil
+	}
+
+	return parsed.Usage
+}
+
+// StreamChunk represents a single chunk in a streamed response.
+type StreamChunk struct {
+	Choices []interface{} `json:"choices"`
+	Usage   *Usage        `json:"usage"`
+}
+
+// extractTokenUsageFromSSELine safely extracts token usage from a single SSE data line.
+// Returns nil if no usage data is found or if parsing fails.
+func extractTokenUsageFromSSELine(line string) *Usage {
+	if !strings.HasPrefix(line, "data: ") {
+		return nil
+	}
+
+	data := strings.TrimPrefix(line, "data: ")
+	if data == "[DONE]" {
+		return nil
+	}
+
+	var chunk map[string]interface{}
+	if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+		return nil
+	}
+
+	usage, exists := chunk["usage"]
+	if !exists || usage == nil {
+		return nil
+	}
+
+	usageMap, ok := usage.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	promptTokens, ok1 := usageMap["prompt_tokens"].(float64)
+	completionTokens, ok2 := usageMap["completion_tokens"].(float64)
+	totalTokens, ok3 := usageMap["total_tokens"].(float64)
+
+	if !ok1 || !ok2 || !ok3 {
+		return nil
+	}
+
+	return &Usage{
+		PromptTokens:     int(promptTokens),
+		CompletionTokens: int(completionTokens),
+		TotalTokens:      int(totalTokens),
 	}
 }

--- a/internal/request_tracking/middleware.go
+++ b/internal/request_tracking/middleware.go
@@ -48,17 +48,6 @@ func RequestTrackingMiddleware(trackingService *Service, logger *logger.Logger) 
 			slog.String("base_url", baseURL),
 			slog.String("method", c.Request.Method))
 
-		info := RequestInfo{
-			UserID:   userID,
-			Endpoint: endpoint,
-			Model:    "", // Not extracting model initially.
-			Provider: provider,
-		}
-
-		if err := trackingService.LogRequestAsync(c.Request.Context(), info); err != nil {
-			log.Error("failed to queue request log", slog.String("error", err.Error()))
-		}
-
 		c.Next()
 	}
 }

--- a/internal/storage/pg/migrations/004_add_token_usage.sql
+++ b/internal/storage/pg/migrations/004_add_token_usage.sql
@@ -1,0 +1,43 @@
+-- +goose Up
+-- Add token usage columns to request_logs table
+ALTER TABLE request_logs 
+ADD COLUMN IF NOT EXISTS prompt_tokens     INTEGER,
+ADD COLUMN IF NOT EXISTS completion_tokens INTEGER,
+ADD COLUMN IF NOT EXISTS total_tokens      INTEGER;
+
+-- Create index for efficient token-based queries
+CREATE INDEX IF NOT EXISTS idx_request_logs_tokens ON request_logs (user_id, created_at, total_tokens) WHERE total_tokens IS NOT NULL;
+
+-- Create materialized view for fast token-based rate limiting queries
+CREATE MATERIALIZED VIEW IF NOT EXISTS user_token_usage_daily AS
+SELECT 
+    user_id,
+    DATE_TRUNC('day', created_at) as day_bucket,
+    COUNT(*) as request_count,
+    COALESCE(SUM(prompt_tokens), 0) as total_prompt_tokens,
+    COALESCE(SUM(completion_tokens), 0) as total_completion_tokens,
+    COALESCE(SUM(total_tokens), 0) as total_tokens_used
+FROM request_logs 
+WHERE created_at >= NOW() - INTERVAL '7 days'
+GROUP BY user_id, DATE_TRUNC('day', created_at);
+
+-- Create unique index for efficient refreshes and queries
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_token_usage_daily_unique 
+ON user_token_usage_daily (user_id, day_bucket);
+
+-- Create additional index for fast token lookups
+CREATE INDEX IF NOT EXISTS idx_user_token_usage_daily_tokens 
+ON user_token_usage_daily (user_id, total_tokens_used);
+
+-- +goose Down
+-- Remove indexes and materialized view
+DROP INDEX IF EXISTS idx_user_token_usage_daily_tokens;
+DROP INDEX IF EXISTS idx_user_token_usage_daily_unique;
+DROP MATERIALIZED VIEW IF EXISTS user_token_usage_daily;
+DROP INDEX IF EXISTS idx_request_logs_tokens;
+
+-- Remove token columns
+ALTER TABLE request_logs 
+DROP COLUMN IF EXISTS total_tokens,
+DROP COLUMN IF EXISTS completion_tokens,
+DROP COLUMN IF EXISTS prompt_tokens;

--- a/internal/storage/pg/queries/request_logs.sql
+++ b/internal/storage/pg/queries/request_logs.sql
@@ -1,6 +1,6 @@
 -- name: CreateRequestLog :exec
-INSERT INTO request_logs (user_id, endpoint, model, provider) 
-VALUES ($1, $2, $3, $4);
+INSERT INTO request_logs (user_id, endpoint, model, provider, prompt_tokens, completion_tokens, total_tokens) 
+VALUES ($1, $2, $3, $4, $5, $6, $7);
 
 -- name: GetUserRequestCountInTimeWindow :one
 SELECT COUNT(*) 
@@ -14,5 +14,14 @@ FROM user_request_counts_daily
 WHERE user_id = $1 
   AND day_bucket = DATE_TRUNC('day', NOW());
 
+-- name: GetUserTokenUsageInLastDay :one
+SELECT COALESCE(SUM(total_tokens_used), 0)::BIGINT as total_tokens
+FROM user_token_usage_daily 
+WHERE user_id = $1 
+  AND day_bucket = DATE_TRUNC('day', NOW());
+
 -- name: RefreshUserRequestCountsView :exec
-REFRESH MATERIALIZED VIEW CONCURRENTLY user_request_counts_daily; 
+REFRESH MATERIALIZED VIEW CONCURRENTLY user_request_counts_daily;
+
+-- name: RefreshUserTokenUsageView :exec
+REFRESH MATERIALIZED VIEW CONCURRENTLY user_token_usage_daily; 

--- a/internal/storage/pg/sqlc/models.go
+++ b/internal/storage/pg/sqlc/models.go
@@ -5,6 +5,7 @@
 package pgdb
 
 import (
+	"database/sql"
 	"time"
 )
 
@@ -25,12 +26,15 @@ type InviteCode struct {
 }
 
 type RequestLog struct {
-	ID        int64     `json:"id"`
-	UserID    string    `json:"userId"`
-	Endpoint  string    `json:"endpoint"`
-	Model     *string   `json:"model"`
-	Provider  string    `json:"provider"`
-	CreatedAt time.Time `json:"createdAt"`
+	ID               int64         `json:"id"`
+	UserID           string        `json:"userId"`
+	Endpoint         string        `json:"endpoint"`
+	Model            *string       `json:"model"`
+	Provider         string        `json:"provider"`
+	CreatedAt        time.Time     `json:"createdAt"`
+	PromptTokens     sql.NullInt32 `json:"promptTokens"`
+	CompletionTokens sql.NullInt32 `json:"completionTokens"`
+	TotalTokens      sql.NullInt32 `json:"totalTokens"`
 }
 
 type TelegramChat struct {
@@ -45,4 +49,13 @@ type UserRequestCountsDaily struct {
 	UserID       string    `json:"userId"`
 	DayBucket    time.Time `json:"dayBucket"`
 	RequestCount int64     `json:"requestCount"`
+}
+
+type UserTokenUsageDaily struct {
+	UserID                string    `json:"userId"`
+	DayBucket             time.Time `json:"dayBucket"`
+	RequestCount          int64     `json:"requestCount"`
+	TotalPromptTokens     int64     `json:"totalPromptTokens"`
+	TotalCompletionTokens int64     `json:"totalCompletionTokens"`
+	TotalTokensUsed       int64     `json:"totalTokensUsed"`
 }

--- a/internal/storage/pg/sqlc/querier.go
+++ b/internal/storage/pg/sqlc/querier.go
@@ -22,8 +22,10 @@ type Querier interface {
 	GetTelegramChatByChatUUID(ctx context.Context, chatUuid string) (TelegramChat, error)
 	GetUserRequestCountInLastDay(ctx context.Context, userID string) (int64, error)
 	GetUserRequestCountInTimeWindow(ctx context.Context, arg GetUserRequestCountInTimeWindowParams) (int64, error)
+	GetUserTokenUsageInLastDay(ctx context.Context, userID string) (int64, error)
 	ListTelegramChats(ctx context.Context) ([]TelegramChat, error)
 	RefreshUserRequestCountsView(ctx context.Context) error
+	RefreshUserTokenUsageView(ctx context.Context) error
 	ResetInviteCode(ctx context.Context, codeHash string) error
 	SoftDeleteInviteCode(ctx context.Context, id int64) error
 	UpdateInviteCodeActive(ctx context.Context, arg UpdateInviteCodeActiveParams) error

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -54,6 +54,16 @@ sql:
               pointer: true
           - column: "user_request_counts_daily.day_bucket"
             go_type: "time.Time"
+          - column: "user_token_usage_daily.day_bucket"
+            go_type: "time.Time"
+          - column: "user_token_usage_daily.request_count"
+            go_type: "int64"
+          - column: "user_token_usage_daily.total_prompt_tokens"
+            go_type: "int64"
+          - column: "user_token_usage_daily.total_completion_tokens"
+            go_type: "int64"
+          - column: "user_token_usage_daily.total_tokens_used"
+            go_type: "int64"
           - db_type: "text"
             nullable: true
             go_type:


### PR DESCRIPTION
1. Logs token usage for each proxied request.
2. Parses token usage from both streaming and non-streaming responses and maintains the stream to the client.
3. Logs the token usage for each request to the existing request logs db.

After testing on dev, we can move to using token based rate limiting instead of request count based rate limiting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token usage (prompt, completion, and total tokens) is now tracked and logged for relevant API requests.
  * Users' daily token usage is aggregated and available for reporting.
  * Enhanced logging provides more detailed information about request processing and token consumption.

* **Database**
  * Added new columns to store token usage in request logs.
  * Introduced a materialized view to summarize daily token usage per user for improved analytics and performance.

* **Bug Fixes**
  * Improved handling and logging of both streaming and non-streaming API responses to ensure accurate token tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->