### PR TITLE
Feat/private search

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -327,7 +327,6 @@ func setupRESTServer(input restServerInput) *gin.Engine {
 		// Search API routes (protected)
 		search := api.Group("/search")
 		{
-			search.GET("", input.searchHandler.SearchHandler)        // GET /api/v1/search?q=query
 			search.POST("", input.searchHandler.PostSearchHandler)  // POST /api/v1/search
 		}
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -324,11 +324,8 @@ func setupRESTServer(input restServerInput) *gin.Engine {
 			rateLimit.GET("/status", request_tracking.RateLimitStatusHandler(input.requestTrackingService))
 		}
 
-		// Search API routes (protected)
-		search := api.Group("/search")
-		{
-			search.POST("", input.searchHandler.PostSearchHandler)  // POST /api/v1/search
-		}
+		// Search API route (protected)
+		api.POST("/search", input.searchHandler.PostSearchHandler)  // POST /api/v1/search
 	}
 
 	// Protected proxy routes

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -39,6 +39,7 @@ var allowedBaseURLs = map[string]string{
 	"https://openrouter.ai/api/v1":     os.Getenv("OPENROUTER_API_KEY"),
 	"https://api.openai.com/v1":        os.Getenv("OPENAI_API_KEY"),
 	"https://inference.tinfoil.sh/v1/": os.Getenv("TINFOIL_API_KEY"),
+	"https://serpapi.com":              os.Getenv("SERPAPI_API_KEY"),
 }
 
 func waHandler(logger *logger.Logger) gin.HandlerFunc {
@@ -324,11 +325,16 @@ func setupRESTServer(input restServerInput) *gin.Engine {
 	proxyGroup := router.Group("/")
 	proxyGroup.Use(request_tracking.RequestTrackingMiddleware(input.requestTrackingService, input.logger))
 	{
+		// AI service endpoints
 		proxyGroup.POST("/chat/completions", proxy.ProxyHandler(input.logger, input.requestTrackingService))
 		proxyGroup.POST("/embeddings", proxy.ProxyHandler(input.logger, input.requestTrackingService))
 		proxyGroup.POST("/audio/speech", proxy.ProxyHandler(input.logger, input.requestTrackingService))
 		proxyGroup.POST("/audio/transcriptions", proxy.ProxyHandler(input.logger, input.requestTrackingService))
 		proxyGroup.POST("/audio/translations", proxy.ProxyHandler(input.logger, input.requestTrackingService))
+		
+		// SerpAPI search endpoints
+		proxyGroup.GET("/search.json", proxy.ProxyHandler(input.logger, input.requestTrackingService))
+		proxyGroup.POST("/search.json", proxy.ProxyHandler(input.logger, input.requestTrackingService))
 	}
 
 	return router

--- a/deploy/enclaver.yaml
+++ b/deploy/enclaver.yaml
@@ -36,6 +36,7 @@ egress:
   - api.openai.com
   - inference.tinfoil.sh
   - openrouter.ai
+  - serpapi.com
   # aws-0-us-east-2.pooler.supabase.com
   - 3.13.175.194
   - 3.139.14.59
@@ -69,6 +70,7 @@ env:
 - REQUEST_TRACKING_BUFFER_SIZE
 - REQUEST_TRACKING_TIMEOUT_SECONDS
 - REQUEST_TRACKING_WORKER_POOL_SIZE
+- SERPAPI_API_KEY
 - SERVER_SHUTDOWN_TIMEOUT_SECONDS
 - SLACK_CLIENT_ID
 - SLACK_CLIENT_SECRET

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	OpenAIAPIKey          string
 	OpenRouterAPIKey      string
 	TinfoilAPIKey         string
+	SerpAPIKey            string
 	ValidatorType         string // "jwk" or "firebase"
 	JWTJWKSURL            string
 	FirebaseCredJSON      string
@@ -110,6 +111,9 @@ func LoadConfig() {
 		// Tinfoil
 		TinfoilAPIKey: getEnvOrDefault("TINFOIL_API_KEY", ""),
 
+		// SerpAPI
+		SerpAPIKey: getEnvOrDefault("SERPAPI_API_KEY", ""),
+
 		// Validator
 		ValidatorType:    getEnvOrDefault("VALIDATOR_TYPE", "firebase"),
 		JWTJWKSURL:       getEnvOrDefault("JWT_JWKS_URL", ""),
@@ -176,6 +180,10 @@ func LoadConfig() {
 
 	if AppConfig.ReplicateAPIToken == "" {
 		log.Println("Warning: Replicate API token is missing. Please set REPLICATE_API_TOKEN environment variable.")
+	}
+
+	if AppConfig.SerpAPIKey == "" {
+		log.Println("Warning: SerpAPI key is missing. Please set SERPAPI_API_KEY environment variable.")
 	}
 
 	if AppConfig.TelegramToken != "" {

--- a/internal/proxy/handlers.go
+++ b/internal/proxy/handlers.go
@@ -145,8 +145,16 @@ func ProxyHandler(logger *logger.Logger, trackingService *request_tracking.Servi
 			orig(r)
 			r.Host = target.Host
 
-			// Set Authorization header with Bearer token
-			r.Header.Set("Authorization", "Bearer "+apiKey)
+			// Handle authentication based on service type
+			if baseURL == "https://serpapi.com" {
+				// SerpAPI uses query parameter authentication
+				q := r.URL.Query()
+				q.Set("api_key", apiKey)
+				r.URL.RawQuery = q.Encode()
+			} else {
+				// Standard Bearer token authentication for AI services
+				r.Header.Set("Authorization", "Bearer "+apiKey)
+			}
 
 			// Handle User-Agent header
 			if userAgent := r.Header.Get("User-Agent"); !strings.Contains(userAgent, "OpenAI/Go") {

--- a/internal/proxy/handlers.go
+++ b/internal/proxy/handlers.go
@@ -145,16 +145,8 @@ func ProxyHandler(logger *logger.Logger, trackingService *request_tracking.Servi
 			orig(r)
 			r.Host = target.Host
 
-			// Handle authentication based on service type
-			if baseURL == "https://serpapi.com" {
-				// SerpAPI uses query parameter authentication
-				q := r.URL.Query()
-				q.Set("api_key", apiKey)
-				r.URL.RawQuery = q.Encode()
-			} else {
-				// Standard Bearer token authentication for AI services
-				r.Header.Set("Authorization", "Bearer "+apiKey)
-			}
+			// Set Authorization header with Bearer token for AI services
+			r.Header.Set("Authorization", "Bearer "+apiKey)
 
 			// Handle User-Agent header
 			if userAgent := r.Header.Get("User-Agent"); !strings.Contains(userAgent, "OpenAI/Go") {

--- a/internal/proxy/utils.go
+++ b/internal/proxy/utils.go
@@ -50,6 +50,8 @@ func getAPIKey(baseURL string, config *config.Config) string {
 		return config.OpenAIAPIKey
 	case "https://inference.tinfoil.sh/v1":
 		return config.TinfoilAPIKey
+	case "https://serpapi.com":
+		return config.SerpAPIKey
 	default:
 		return ""
 	}

--- a/internal/proxy/utils.go
+++ b/internal/proxy/utils.go
@@ -50,8 +50,6 @@ func getAPIKey(baseURL string, config *config.Config) string {
 		return config.OpenAIAPIKey
 	case "https://inference.tinfoil.sh/v1":
 		return config.TinfoilAPIKey
-	case "https://serpapi.com":
-		return config.SerpAPIKey
 	default:
 		return ""
 	}

--- a/internal/search/handlers.go
+++ b/internal/search/handlers.go
@@ -55,9 +55,6 @@ func (h *Handler) PostSearchHandler(c *gin.Context) {
 	if searchReq.Engine == "" {
 		searchReq.Engine = "duckduckgo"
 	}
-	if searchReq.Count <= 0 || searchReq.Count > 30 {
-		searchReq.Count = 10
-	}
 
 	// Validate engine
 	if searchReq.Engine != "duckduckgo" {
@@ -73,7 +70,6 @@ func (h *Handler) PostSearchHandler(c *gin.Context) {
 	log.Info("processing search request",
 		slog.String("query", searchReq.Query),
 		slog.String("engine", searchReq.Engine),
-		slog.Int("count", searchReq.Count),
 		slog.String("user_id", userID))
 
 	// Perform search

--- a/internal/search/handlers.go
+++ b/internal/search/handlers.go
@@ -1,0 +1,187 @@
+package search
+
+import (
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/eternisai/enchanted-proxy/internal/auth"
+	"github.com/eternisai/enchanted-proxy/internal/logger"
+	"github.com/gin-gonic/gin"
+)
+
+// Handler handles HTTP requests for search operations
+type Handler struct {
+	service *Service
+	logger  *logger.Logger
+}
+
+// NewHandler creates a new search handler
+func NewHandler(service *Service, logger *logger.Logger) *Handler {
+	return &Handler{
+		service: service,
+		logger:  logger,
+	}
+}
+
+// SearchHandler handles GET /api/search requests
+// Query parameters:
+//   - q (required): search query
+//   - engine (optional): search engine, default "duckduckgo"
+//   - count (optional): number of results, default 10, max 30
+//   - time_filter (optional): "d", "w", "m", "y"
+//
+// Note: language is always "us-en", safe_search is always "moderate", region is always "us-en"
+func (h *Handler) SearchHandler(c *gin.Context) {
+	log := h.logger.WithContext(c.Request.Context()).WithComponent("search_handler")
+
+	// Get user ID from auth context for logging
+	userID, _ := auth.GetUserUUID(c)
+
+	// Parse query parameters
+	query := strings.TrimSpace(c.Query("q"))
+	if query == "" {
+		log.Warn("search request missing query parameter", slog.String("user_id", userID))
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Missing required parameter 'q' (search query)",
+		})
+		return
+	}
+
+	// Parse optional parameters
+	engine := c.DefaultQuery("engine", "duckduckgo")
+	countStr := c.DefaultQuery("count", "10")
+	timeFilter := c.Query("time_filter")
+
+	// Validate and parse count
+	count, err := strconv.Atoi(countStr)
+	if err != nil || count < 1 || count > 30 {
+		count = 10
+	}
+
+	// Validate engine
+	if engine != "duckduckgo" {
+		log.Warn("unsupported search engine requested", 
+			slog.String("engine", engine), 
+			slog.String("user_id", userID))
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Unsupported search engine. Currently supported: 'duckduckgo'",
+		})
+		return
+	}
+
+	// Build search request
+	searchReq := SearchRequest{
+		Query:      query,
+		Engine:     engine,
+		Count:      count,
+		TimeFilter: timeFilter,
+	}
+
+	log.Info("processing search request",
+		slog.String("query", query),
+		slog.String("engine", engine),
+		slog.Int("count", count),
+		slog.String("user_id", userID))
+
+	// Perform search
+	result, err := h.service.SearchDuckDuckGo(c.Request.Context(), searchReq)
+	if err != nil {
+		log.Error("search request failed",
+			slog.String("query", query),
+			slog.String("engine", engine),
+			slog.String("error", err.Error()),
+			slog.String("user_id", userID))
+		
+		// Don't expose internal error details to client
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Search request failed",
+		})
+		return
+	}
+
+	log.Info("search request completed",
+		slog.String("query", query),
+		slog.Int("results_count", len(result.OrganicResults)),
+		slog.String("processing_time", result.ProcessingTime),
+		slog.String("user_id", userID))
+
+	c.JSON(http.StatusOK, result)
+}
+
+// PostSearchHandler handles POST /api/search requests with JSON body
+func (h *Handler) PostSearchHandler(c *gin.Context) {
+	log := h.logger.WithContext(c.Request.Context()).WithComponent("search_handler")
+
+	// Get user ID from auth context for logging
+	userID, _ := auth.GetUserUUID(c)
+
+	var searchReq SearchRequest
+	if err := c.ShouldBindJSON(&searchReq); err != nil {
+		log.Warn("invalid search request body", 
+			slog.String("error", err.Error()),
+			slog.String("user_id", userID))
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid request body: " + err.Error(),
+		})
+		return
+	}
+
+	// Validate required fields
+	searchReq.Query = strings.TrimSpace(searchReq.Query)
+	if searchReq.Query == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Missing required field 'query'",
+		})
+		return
+	}
+
+	// Set defaults
+	if searchReq.Engine == "" {
+		searchReq.Engine = "duckduckgo"
+	}
+	if searchReq.Count <= 0 || searchReq.Count > 30 {
+		searchReq.Count = 10
+	}
+
+	// Validate engine
+	if searchReq.Engine != "duckduckgo" {
+		log.Warn("unsupported search engine requested", 
+			slog.String("engine", searchReq.Engine), 
+			slog.String("user_id", userID))
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Unsupported search engine. Currently supported: 'duckduckgo'",
+		})
+		return
+	}
+
+	log.Info("processing search request",
+		slog.String("query", searchReq.Query),
+		slog.String("engine", searchReq.Engine),
+		slog.Int("count", searchReq.Count),
+		slog.String("user_id", userID))
+
+	// Perform search
+	result, err := h.service.SearchDuckDuckGo(c.Request.Context(), searchReq)
+	if err != nil {
+		log.Error("search request failed",
+			slog.String("query", searchReq.Query),
+			slog.String("engine", searchReq.Engine),
+			slog.String("error", err.Error()),
+			slog.String("user_id", userID))
+		
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Search request failed",
+		})
+		return
+	}
+
+	log.Info("search request completed",
+		slog.String("query", searchReq.Query),
+		slog.Int("results_count", len(result.OrganicResults)),
+		slog.String("processing_time", result.ProcessingTime),
+		slog.String("user_id", userID))
+
+	c.JSON(http.StatusOK, result)
+}

--- a/internal/search/handlers.go
+++ b/internal/search/handlers.go
@@ -68,17 +68,25 @@ func (h *Handler) PostSearchHandler(c *gin.Context) {
 	}
 
 	log.Info("processing search request",
-		slog.String("query", searchReq.Query),
 		slog.String("engine", searchReq.Engine),
+		slog.String("user_id", userID))
+	
+	// Log query at debug level for troubleshooting (if needed)
+	log.Debug("search query details",
+		slog.String("query", searchReq.Query),
 		slog.String("user_id", userID))
 
 	// Perform search
 	result, err := h.service.SearchDuckDuckGo(c.Request.Context(), searchReq)
 	if err != nil {
 		log.Error("search request failed",
-			slog.String("query", searchReq.Query),
 			slog.String("engine", searchReq.Engine),
 			slog.String("error", err.Error()),
+			slog.String("user_id", userID))
+		
+		// Log query at debug level for troubleshooting
+		log.Debug("failed search query details",
+			slog.String("query", "[REDACTED]"),
 			slog.String("user_id", userID))
 		
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -88,7 +96,6 @@ func (h *Handler) PostSearchHandler(c *gin.Context) {
 	}
 
 	log.Info("search request completed",
-		slog.String("query", searchReq.Query),
 		slog.Int("results_count", len(result.OrganicResults)),
 		slog.String("processing_time", result.ProcessingTime),
 		slog.String("user_id", userID))

--- a/internal/search/handlers.go
+++ b/internal/search/handlers.go
@@ -3,7 +3,6 @@ package search
 import (
 	"log/slog"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/eternisai/enchanted-proxy/internal/auth"
@@ -23,91 +22,6 @@ func NewHandler(service *Service, logger *logger.Logger) *Handler {
 		service: service,
 		logger:  logger,
 	}
-}
-
-// SearchHandler handles GET /api/search requests
-// Query parameters:
-//   - q (required): search query
-//   - engine (optional): search engine, default "duckduckgo"
-//   - count (optional): number of results, default 10, max 30
-//   - time_filter (optional): "d", "w", "m", "y"
-//
-// Note: language is always "us-en", safe_search is always "moderate", region is always "us-en"
-func (h *Handler) SearchHandler(c *gin.Context) {
-	log := h.logger.WithContext(c.Request.Context()).WithComponent("search_handler")
-
-	// Get user ID from auth context for logging
-	userID, _ := auth.GetUserUUID(c)
-
-	// Parse query parameters
-	query := strings.TrimSpace(c.Query("q"))
-	if query == "" {
-		log.Warn("search request missing query parameter", slog.String("user_id", userID))
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "Missing required parameter 'q' (search query)",
-		})
-		return
-	}
-
-	// Parse optional parameters
-	engine := c.DefaultQuery("engine", "duckduckgo")
-	countStr := c.DefaultQuery("count", "10")
-	timeFilter := c.Query("time_filter")
-
-	// Validate and parse count
-	count, err := strconv.Atoi(countStr)
-	if err != nil || count < 1 || count > 30 {
-		count = 10
-	}
-
-	// Validate engine
-	if engine != "duckduckgo" {
-		log.Warn("unsupported search engine requested", 
-			slog.String("engine", engine), 
-			slog.String("user_id", userID))
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "Unsupported search engine. Currently supported: 'duckduckgo'",
-		})
-		return
-	}
-
-	// Build search request
-	searchReq := SearchRequest{
-		Query:      query,
-		Engine:     engine,
-		Count:      count,
-		TimeFilter: timeFilter,
-	}
-
-	log.Info("processing search request",
-		slog.String("query", query),
-		slog.String("engine", engine),
-		slog.Int("count", count),
-		slog.String("user_id", userID))
-
-	// Perform search
-	result, err := h.service.SearchDuckDuckGo(c.Request.Context(), searchReq)
-	if err != nil {
-		log.Error("search request failed",
-			slog.String("query", query),
-			slog.String("engine", engine),
-			slog.String("error", err.Error()),
-			slog.String("user_id", userID))
-		
-		// Don't expose internal error details to client
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "Search request failed",
-		})
-		return
-	}
-
-	log.Info("search request completed",
-		slog.String("query", query),
-		slog.Int("results_count", len(result.OrganicResults)),
-		slog.String("processing_time", result.ProcessingTime),
-		slog.String("user_id", userID))
-
-	c.JSON(http.StatusOK, result)
 }
 
 // PostSearchHandler handles POST /api/search requests with JSON body

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -35,7 +35,6 @@ func NewService(logger *logger.Logger) *Service {
 type SearchRequest struct {
 	Query      string `json:"query" binding:"required"`
 	Engine     string `json:"engine,omitempty"`     // default: "duckduckgo"
-	Count      int    `json:"count,omitempty"`      // default: 10
 	TimeFilter string `json:"time_filter,omitempty"` // "d", "w", "m", "y"
 }
 
@@ -148,11 +147,8 @@ func (s *Service) buildSerpAPIURL(req SearchRequest) (string, error) {
 	params.Set("engine", "duckduckgo")
 	params.Set("q", req.Query)
 
-	// Set count (results per page)
-	count := req.Count
-	if count <= 0 || count > 30 {
-		count = 10 // Default to 10, max 30 for DuckDuckGo
-	}
+	// Set count (results per page) - always use default of 10
+	count := 10
 	params.Set("s", fmt.Sprintf("%d", count))
 
 	// Always use US English settings

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -147,14 +147,10 @@ func (s *Service) buildSerpAPIURL(req SearchRequest) (string, error) {
 	params.Set("engine", "duckduckgo")
 	params.Set("q", req.Query)
 
-	// Set count (results per page) - always use default of 10
-	count := 10
-	params.Set("s", fmt.Sprintf("%d", count))
-
 	// Always use US English settings
-	params.Set("kl", "us-en")    // Language: US English
-	params.Set("safe_search", "0") // Safe search: moderate
-	params.Set("region", "us-en")  // Region: US English
+	params.Set("kl", "us-en")     // Language/locale: US English (covers region)
+	params.Set("safe", "-1")      // Safe search: moderate (-1=moderate, 1=strict, -2=off)
+	params.Set("no_cache", "true") // Zero trace: prevent caching for privacy
 
 	// Set time filter if provided
 	if req.TimeFilter != "" {

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -1,0 +1,219 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/eternisai/enchanted-proxy/internal/config"
+	"github.com/eternisai/enchanted-proxy/internal/logger"
+)
+
+// Service handles search operations
+type Service struct {
+	httpClient *http.Client
+	logger     *logger.Logger
+	serpAPIKey string
+}
+
+// NewService creates a new search service
+func NewService(logger *logger.Logger) *Service {
+	return &Service{
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		logger:     logger,
+		serpAPIKey: config.AppConfig.SerpAPIKey,
+	}
+}
+
+// SearchRequest represents a search request from the client
+type SearchRequest struct {
+	Query      string `json:"query" binding:"required"`
+	Engine     string `json:"engine,omitempty"`     // default: "duckduckgo"
+	Count      int    `json:"count,omitempty"`      // default: 10
+	TimeFilter string `json:"time_filter,omitempty"` // "d", "w", "m", "y"
+}
+
+// SearchResponse represents the standardized search response
+type SearchResponse struct {
+	Query           string         `json:"query"`
+	Engine          string         `json:"engine"`
+	OrganicResults  []SearchResult `json:"organic_results"`
+	RelatedQueries  []string       `json:"related_queries,omitempty"`
+	SearchMetadata  SearchMetadata `json:"search_metadata"`
+	ProcessingTime  string         `json:"processing_time"`
+}
+
+// SearchResult represents a single search result
+type SearchResult struct {
+	Position int    `json:"position"`
+	Title    string `json:"title"`
+	Link     string `json:"link"`
+	Snippet  string `json:"snippet"`
+	Source   string `json:"source,omitempty"`
+}
+
+// SearchMetadata contains metadata about the search
+type SearchMetadata struct {
+	TotalResults string `json:"total_results,omitempty"`
+	TimeTaken    string `json:"time_taken,omitempty"`
+	Engine       string `json:"engine"`
+	Status       string `json:"status"`
+}
+
+// SerpAPIDuckDuckGoResponse represents the raw SerpAPI DuckDuckGo response
+type SerpAPIDuckDuckGoResponse struct {
+	OrganicResults []struct {
+		Position int    `json:"position"`
+		Title    string `json:"title"`
+		Link     string `json:"link"`
+		Snippet  string `json:"snippet"`
+	} `json:"organic_results"`
+	RelatedSearches []struct {
+		Query string `json:"query"`
+	} `json:"related_searches"`
+	SearchMetadata struct {
+		Status         string `json:"status"`
+		ProcessedAt    string `json:"processed_at"`
+		TotalTimeTaken float64 `json:"total_time_taken"`
+	} `json:"search_metadata"`
+	Error string `json:"error,omitempty"`
+}
+
+// SearchDuckDuckGo performs a DuckDuckGo search via SerpAPI
+func (s *Service) SearchDuckDuckGo(ctx context.Context, req SearchRequest) (*SearchResponse, error) {
+	start := time.Now()
+	
+	if s.serpAPIKey == "" {
+		return nil, fmt.Errorf("SerpAPI key not configured")
+	}
+
+	// Build SerpAPI request URL
+	apiURL, err := s.buildSerpAPIURL(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build API URL: %w", err)
+	}
+
+	// Make HTTP request
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := s.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	// Check for HTTP errors
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("SerpAPI returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Parse SerpAPI response
+	var serpResp SerpAPIDuckDuckGoResponse
+	if err := json.Unmarshal(body, &serpResp); err != nil {
+		return nil, fmt.Errorf("failed to parse SerpAPI response: %w", err)
+	}
+
+	// Check for API errors
+	if serpResp.Error != "" {
+		return nil, fmt.Errorf("SerpAPI error: %s", serpResp.Error)
+	}
+
+	// Convert to standardized response
+	searchResp := s.convertSerpAPIResponse(req, serpResp, time.Since(start))
+
+	return searchResp, nil
+}
+
+// buildSerpAPIURL constructs the SerpAPI request URL
+func (s *Service) buildSerpAPIURL(req SearchRequest) (string, error) {
+	baseURL := "https://serpapi.com/search.json"
+	
+	params := url.Values{}
+	params.Set("api_key", s.serpAPIKey)
+	params.Set("engine", "duckduckgo")
+	params.Set("q", req.Query)
+
+	// Set count (results per page)
+	count := req.Count
+	if count <= 0 || count > 30 {
+		count = 10 // Default to 10, max 30 for DuckDuckGo
+	}
+	params.Set("s", fmt.Sprintf("%d", count))
+
+	// Always use US English settings
+	params.Set("kl", "us-en")    // Language: US English
+	params.Set("safe_search", "0") // Safe search: moderate
+	params.Set("region", "us-en")  // Region: US English
+
+	// Set time filter if provided
+	if req.TimeFilter != "" {
+		params.Set("time", req.TimeFilter)
+	}
+
+	return baseURL + "?" + params.Encode(), nil
+}
+
+// convertSerpAPIResponse converts SerpAPI response to standardized format
+func (s *Service) convertSerpAPIResponse(req SearchRequest, serpResp SerpAPIDuckDuckGoResponse, processingTime time.Duration) *SearchResponse {
+	// Convert organic results
+	results := make([]SearchResult, 0, len(serpResp.OrganicResults))
+	for _, result := range serpResp.OrganicResults {
+		results = append(results, SearchResult{
+			Position: result.Position,
+			Title:    result.Title,
+			Link:     result.Link,
+			Snippet:  result.Snippet,
+			Source:   extractDomain(result.Link),
+		})
+	}
+
+	// Convert related queries
+	relatedQueries := make([]string, 0, len(serpResp.RelatedSearches))
+	for _, related := range serpResp.RelatedSearches {
+		if related.Query != "" {
+			relatedQueries = append(relatedQueries, related.Query)
+		}
+	}
+
+	// Build response
+	engine := req.Engine
+	if engine == "" {
+		engine = "duckduckgo"
+	}
+
+	return &SearchResponse{
+		Query:          req.Query,
+		Engine:         engine,
+		OrganicResults: results,
+		RelatedQueries: relatedQueries,
+		SearchMetadata: SearchMetadata{
+			Engine: engine,
+			Status: serpResp.SearchMetadata.Status,
+			TimeTaken: fmt.Sprintf("%.2fs", serpResp.SearchMetadata.TotalTimeTaken),
+		},
+		ProcessingTime: fmt.Sprintf("%.2fms", float64(processingTime.Nanoseconds())/1000000),
+	}
+}
+
+// extractDomain extracts domain from URL for display
+func extractDomain(urlStr string) string {
+	if u, err := url.Parse(urlStr); err == nil {
+		return u.Host
+	}
+	return ""
+}


### PR DESCRIPTION
Added SerpAPI call integrations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added protected POST /api/v1/search endpoint for web search.
  - Server-side search supports DuckDuckGo via SerpAPI, returning structured JSON results (organic results, related queries, metadata) with fixed 10 results per request.
  - Input is validated, defaults applied (engine defaults to DuckDuckGo), and errors are returned consistently.

- Chores
  - Added SERPAPI_API_KEY env var and deployment egress for serpapi.com.
  - Config logs a warning when SERPAPI_API_KEY is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->