### PR TITLE
feat: support getting analytics from multiple OpenRouter accounts

### DIFF
--- a/.github/workflows/openrouter-analytics.yml
+++ b/.github/workflows/openrouter-analytics.yml
@@ -37,7 +37,7 @@ jobs:
             key_name: OPENROUTER_DESKTOP_API_KEY
             event_name: openrouter_daily_activity_desktop
             account: Desktop
-    
+
     name: Sync ${{ matrix.account }} account
     
     steps:
@@ -54,9 +54,8 @@ jobs:
         pip install requests
         
     - name: Sync OpenRouter analytics to PostHog
-      env:
-        ${{ matrix.key_name }}: ${{ secrets[matrix.api_key_secret] }}
       run: |
+        export ${{ matrix.key_name }}=${{ secrets[matrix.api_key_secret] }}
         CMD="python scripts/sync_openrouter_analytics.py --key-name ${{ matrix.key_name }} --event-name ${{ matrix.event_name }}"
         
         if [ -n "${{ github.event.inputs.date }}" ]; then

--- a/.github/workflows/openrouter-analytics.yml
+++ b/.github/workflows/openrouter-analytics.yml
@@ -29,14 +29,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - api_key_secret: IOS_OPENROUTER_PROVISIONING_KEY
-            key_name: IOS_OPENROUTER_API_KEY
+          - api_key_secret: MOBILE_OPENROUTER_PROVISIONING_KEY
+            key_name: MOBILE_OPENROUTER_API_KEY
             event_name: openrouter_daily_activity
-            account: iOS
-          - api_key_secret: MACOS_OPENROUTER_PROVISIONING_KEY
-            key_name: MACOS_OPENROUTER_API_KEY
-            event_name: openrouter_daily_activity_macos
-            account: macOS
+            account: Mobile
+          - api_key_secret: DESKTOP_OPENROUTER_PROVISIONING_KEY
+            key_name: DESKTOP_OPENROUTER_API_KEY
+            event_name: openrouter_daily_activity_desktop
+            account: Desktop
     
     name: Sync ${{ matrix.account }} account
     

--- a/.github/workflows/openrouter-analytics.yml
+++ b/.github/workflows/openrouter-analytics.yml
@@ -20,13 +20,25 @@ on:
         type: string
 
 env:
-  OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_PROVISIONING_KEY }}
   POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
   POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
 
 jobs:
   fetch-and-send-analytics:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - api_key_secret: IOS_OPENROUTER_PROVISIONING_KEY
+            key_name: IOS_OPENROUTER_API_KEY
+            event_name: openrouter_daily_activity
+            account: iOS
+          - api_key_secret: MACOS_OPENROUTER_PROVISIONING_KEY
+            key_name: MACOS_OPENROUTER_API_KEY
+            event_name: openrouter_daily_activity_macos
+            account: macOS
+    
+    name: Sync ${{ matrix.account }} account
     
     steps:
     - name: Checkout repository
@@ -42,8 +54,10 @@ jobs:
         pip install requests
         
     - name: Sync OpenRouter analytics to PostHog
+      env:
+        ${{ matrix.key_name }}: ${{ secrets[matrix.api_key_secret] }}
       run: |
-        CMD="python scripts/sync_openrouter_analytics.py"
+        CMD="python scripts/sync_openrouter_analytics.py --key-name ${{ matrix.key_name }} --event-name ${{ matrix.event_name }}"
         
         if [ -n "${{ github.event.inputs.date }}" ]; then
           CMD="$CMD --date ${{ github.event.inputs.date }}"
@@ -54,5 +68,5 @@ jobs:
           fi
         fi
         
-        echo "Running: $CMD"
+        echo "Running ${{ matrix.account }} account: $CMD"
         eval $CMD

--- a/.github/workflows/openrouter-analytics.yml
+++ b/.github/workflows/openrouter-analytics.yml
@@ -29,12 +29,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - api_key_secret: MOBILE_OPENROUTER_PROVISIONING_KEY
-            key_name: MOBILE_OPENROUTER_API_KEY
+          - api_key_secret: OPENROUTER_MOBILE_PROVISIONING_KEY
+            key_name: OPENROUTER_MOBILE_API_KEY
             event_name: openrouter_daily_activity
             account: Mobile
-          - api_key_secret: DESKTOP_OPENROUTER_PROVISIONING_KEY
-            key_name: DESKTOP_OPENROUTER_API_KEY
+          - api_key_secret: OPENROUTER_DESKTOP_PROVISIONING_KEY
+            key_name: OPENROUTER_DESKTOP_API_KEY
             event_name: openrouter_daily_activity_desktop
             account: Desktop
     

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -274,7 +274,7 @@ func setupRESTServer(input restServerInput) *gin.Engine {
 	router.Use(func(c *gin.Context) {
 		c.Header("Access-Control-Allow-Origin", "*")
 		c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		c.Header("Access-Control-Allow-Headers", "Origin, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, X-BASE-URL")
+		c.Header("Access-Control-Allow-Headers", "Origin, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, X-BASE-URL, X-Client-Platform")
 
 		if c.Request.Method == "OPTIONS" {
 			c.AbortWithStatus(204)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,26 +9,27 @@ import (
 )
 
 type Config struct {
-	Port                  string
-	GinMode               string
-	FirebaseProjectID     string
-	DatabaseURL           string
-	GoogleClientID        string
-	GoogleClientSecret    string
-	SlackClientID         string
-	SlackClientSecret     string
-	TwitterClientID       string
-	TwitterClientSecret   string
-	ComposioAPIKey        string
-	ComposioTwitterConfig string
-	OpenAIAPIKey          string
-	OpenRouterAPIKey      string
-	TinfoilAPIKey         string
-	SerpAPIKey            string
-	ExaAPIKey             string
-	ValidatorType         string // "jwk" or "firebase"
-	JWTJWKSURL            string
-	FirebaseCredJSON      string
+	Port                    string
+	GinMode                 string
+	FirebaseProjectID       string
+	DatabaseURL             string
+	GoogleClientID          string
+	GoogleClientSecret      string
+	SlackClientID           string
+	SlackClientSecret       string
+	TwitterClientID         string
+	TwitterClientSecret     string
+	ComposioAPIKey          string
+	ComposioTwitterConfig   string
+	OpenAIAPIKey            string
+	OpenRouterMobileAPIKey  string
+	OpenRouterDesktopAPIKey string
+	TinfoilAPIKey           string
+	SerpAPIKey              string
+	ExaAPIKey               string
+	ValidatorType           string // "jwk" or "firebase"
+	JWTJWKSURL              string
+	FirebaseCredJSON        string
 
 	// MCP
 	PerplexityAPIKey  string
@@ -106,8 +107,11 @@ func LoadConfig() {
 		ComposioTwitterConfig: getEnvOrDefault("COMPOSIO_TWITTER_CONFIG", ""),
 
 		// OpenAI
-		OpenAIAPIKey:     getEnvOrDefault("OPENAI_API_KEY", ""),
-		OpenRouterAPIKey: getEnvOrDefault("OPENROUTER_API_KEY", ""),
+		OpenAIAPIKey: getEnvOrDefault("OPENAI_API_KEY", ""),
+
+		// OpenRouter
+		OpenRouterMobileAPIKey:  getEnvOrDefault("OPENROUTER_MOBILE_API_KEY", ""),
+		OpenRouterDesktopAPIKey: getEnvOrDefault("OPENROUTER_DESKTOP_API_KEY", ""),
 
 		// Tinfoil
 		TinfoilAPIKey: getEnvOrDefault("TINFOIL_API_KEY", ""),

--- a/internal/proxy/handlers.go
+++ b/internal/proxy/handlers.go
@@ -89,9 +89,8 @@ func ProxyHandler(logger *logger.Logger, trackingService *request_tracking.Servi
 
 		platform := c.GetHeader("X-Client-Platform")
 		if platform == "" {
-			log.Warn("missing client platform header")
-			c.JSON(http.StatusBadRequest, gin.H{"error": "X-Client-Platform header is required"})
-			return
+			log.Warn("missing client platform header, defaulting to mobile")
+			platform = "mobile"
 		}
 
 		// Check if base URL is in our allowed dictionary
@@ -168,6 +167,7 @@ func ProxyHandler(logger *logger.Logger, trackingService *request_tracking.Servi
 			r.Header.Del("X-Forwarded-For")
 			r.Header.Del("X-Real-Ip")
 			r.Header.Del("X-BASE-URL") // Remove our custom header before forwarding
+			r.Header.Del("X-Client-Platform")
 		}
 
 		// Some canceled requests by clients could cause panic.

--- a/internal/proxy/handlers.go
+++ b/internal/proxy/handlers.go
@@ -87,8 +87,15 @@ func ProxyHandler(logger *logger.Logger, trackingService *request_tracking.Servi
 			return
 		}
 
+		platform := c.GetHeader("X-Client-Platform")
+		if platform == "" {
+			log.Warn("missing client platform header")
+			c.JSON(http.StatusBadRequest, gin.H{"error": "X-Client-Platform header is required"})
+			return
+		}
+
 		// Check if base URL is in our allowed dictionary
-		apiKey := getAPIKey(baseURL, config.AppConfig)
+		apiKey := getAPIKey(baseURL, platform, config.AppConfig)
 		if apiKey == "" {
 			log.Warn("unauthorized base url", slog.String("base_url", baseURL))
 			c.JSON(http.StatusForbidden, gin.H{"error": "Unauthorized base URL"})

--- a/internal/proxy/utils.go
+++ b/internal/proxy/utils.go
@@ -42,10 +42,10 @@ func logRequestBody(body []byte, maxSize int) string {
 	return bodyStr[:maxSize] + "..."
 }
 
-func getAPIKey(baseURL string, config *config.Config) string {
+func getAPIKey(baseURL string, platform string, config *config.Config) string {
 	switch baseURL {
 	case "https://openrouter.ai/api/v1":
-		return config.OpenRouterAPIKey
+		return getOpenRouterAPIKey(platform, config)
 	case "https://api.openai.com/v1":
 		return config.OpenAIAPIKey
 	case "https://inference.tinfoil.sh/v1":
@@ -126,5 +126,16 @@ func extractTokenUsageFromSSELine(line string) *Usage {
 		PromptTokens:     int(promptTokens),
 		CompletionTokens: int(completionTokens),
 		TotalTokens:      int(totalTokens),
+	}
+}
+
+func getOpenRouterAPIKey(platform string, config *config.Config) string {
+	switch platform {
+	case "mobile":
+		return config.OpenRouterMobileAPIKey
+	case "desktop":
+		return config.OpenRouterDesktopAPIKey
+	default:
+		return ""
 	}
 }


### PR DESCRIPTION
Routes requests to different OpenRouter accounts based on `X-Client-Platform: mobile|desktop` headers.

**Note**: Need to set new environment variables in Vault.

Also supports collecting analytics from multiple accounts and send them to PostHog.

Safe to merge without client side updates as it falls back to mobile.

Fixes [ETERNIS-1640](https://linear.app/eternis/issue/ETERNIS-1640/add-header-based-routing-to-enchanted-proxy) and [ETERNIS-1642](https://linear.app/eternis/issue/ETERNIS-1642/support-multiple-openrouter-accounts-for-analytics-data-workflow)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Separate OpenRouter API keys for Mobile and Desktop.
  * Server accepts X-Client-Platform (defaults to Mobile when absent); CORS allows that header.

* **Chores**
  * CI analytics workflow now runs per-account (Mobile/Desktop) with dynamic job names and clearer logs.
  * Analytics sync tool adds CLI options to select the API key env var and customize the event name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->