### PR TITLE
feat: support proxying to Near AI

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -41,6 +41,7 @@ var allowedBaseURLs = map[string]string{
 	"https://openrouter.ai/api/v1":     os.Getenv("OPENROUTER_API_KEY"),
 	"https://api.openai.com/v1":        os.Getenv("OPENAI_API_KEY"),
 	"https://inference.tinfoil.sh/v1/": os.Getenv("TINFOIL_API_KEY"),
+	"https://cloud-api.near.ai/v1":     os.Getenv("NEAR_API_KEY"),
 }
 
 func waHandler(logger *logger.Logger) gin.HandlerFunc {

--- a/deploy/enclaver.yaml
+++ b/deploy/enclaver.yaml
@@ -41,6 +41,7 @@ egress:
   - openrouter.ai
   - serpapi.com
   - api.exa.ai
+  - cloud-api.near.ai
   # aws-0-us-east-2.pooler.supabase.com
   - 3.13.175.194
   - 3.139.14.59
@@ -68,6 +69,7 @@ env:
 - LOG_FORMAT
 - LOG_LEVEL
 - NATS_URL
+- NEAR_API_KEY
 - OPENAI_API_KEY
 - OPENROUTER_API_KEY
 - OPENROUTER_DESKTOP_API_KEY

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	OpenRouterMobileAPIKey  string
 	OpenRouterDesktopAPIKey string
 	TinfoilAPIKey           string
+	NearAPIKey              string
 	SerpAPIKey              string
 	ExaAPIKey               string
 	ValidatorType           string // "jwk" or "firebase"
@@ -126,6 +127,9 @@ func LoadConfig() {
 
 		// Tinfoil
 		TinfoilAPIKey: getEnvOrDefault("TINFOIL_API_KEY", ""),
+
+		// Near
+		NearAPIKey: getEnvOrDefault("NEAR_API_KEY", ""),
 
 		// SerpAPI
 		SerpAPIKey: getEnvOrDefault("SERPAPI_API_KEY", ""),

--- a/internal/proxy/utils.go
+++ b/internal/proxy/utils.go
@@ -50,6 +50,8 @@ func getAPIKey(baseURL string, platform string, config *config.Config) string {
 		return config.OpenAIAPIKey
 	case "https://inference.tinfoil.sh/v1":
 		return config.TinfoilAPIKey
+	case "https://cloud-api.near.ai/v1":
+		return config.NearAPIKey
 	default:
 		return ""
 	}


### PR DESCRIPTION
You can now use `https://cloud-api.near.ai/v1` baseURL to proxy to Near AI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for the NEAR Cloud API endpoint.
  - Introduced a NEAR_API_KEY environment variable for seamless authentication.
  - Requests to the NEAR Cloud API now automatically use the configured key.

- Chores
  - Updated deployment configuration to allow egress to the NEAR Cloud API domain.
  - Propagated NEAR_API_KEY in deployment environments for easier setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->