### PR TITLE
fix: count token usage for pro model

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -629,8 +629,13 @@ func main() {
 	// Shutdown the model routing fallback service
 	fallbackService.Shutdown()
 
-	// Shutdown the request tracking service worker pool
-	requestTrackingService.Shutdown()
+	// Shutdown the request tracking service worker pool. Bounded by the
+	// same deadline as HTTP shutdown so a stuck DB cannot hang process exit.
+	rtCtx, rtCancel := context.WithTimeout(context.Background(), time.Duration(config.AppConfig.ServerShutdownTimeoutSeconds)*time.Second)
+	if err := requestTrackingService.Shutdown(rtCtx); err != nil {
+		log.Warn("request tracking service shutdown timed out", slog.String("error", err.Error()))
+	}
+	rtCancel()
 	log.Info("request tracking service shutdown complete")
 
 	// Shutdown the task service (close Temporal client)

--- a/internal/background/polling_worker.go
+++ b/internal/background/polling_worker.go
@@ -328,13 +328,19 @@ func (w *PollingWorker) fetchAndSaveResponse(ctx context.Context) error {
 			slog.String("user_id", w.job.UserID))
 		// Note: Consider failing the request or alerting in production
 	} else {
-		// Calculate plan tokens using multiplier (e.g., 50× for GPT-5 Pro)
-		planTokens := int(float64(content.Usage.TotalTokens) * w.tokenMultiplier)
+		// Responses API returns input_tokens/output_tokens; Chat Completions
+		// returns prompt_tokens/completion_tokens. UsageInfo accepts both.
+		promptTokens := content.Usage.Prompt()
+		completionTokens := content.Usage.Completion()
+		totalTokens := content.Usage.TotalTokens
+
+		// Calculate plan tokens using multiplier (e.g., 54× for GPT-5 Pro)
+		planTokens := int(float64(totalTokens) * w.tokenMultiplier)
 
 		tokenData := &request_tracking.TokenUsageWithMultiplier{
-			PromptTokens:     content.Usage.PromptTokens,
-			CompletionTokens: content.Usage.CompletionTokens,
-			TotalTokens:      content.Usage.TotalTokens,
+			PromptTokens:     promptTokens,
+			CompletionTokens: completionTokens,
+			TotalTokens:      totalTokens,
 			Multiplier:       w.tokenMultiplier,
 			PlanTokens:       planTokens,
 		}
@@ -344,30 +350,36 @@ func (w *PollingWorker) fetchAndSaveResponse(ctx context.Context) error {
 			Endpoint:         "/v1/responses",
 			Model:            w.job.Model,
 			Provider:         "GPT 5 Pro",
-			PromptTokens:     &content.Usage.PromptTokens,
-			CompletionTokens: &content.Usage.CompletionTokens,
-			TotalTokens:      &content.Usage.TotalTokens,
+			PromptTokens:     &promptTokens,
+			CompletionTokens: &completionTokens,
+			TotalTokens:      &totalTokens,
 			PlanTokens:       &planTokens,
 			Multiplier:       &w.tokenMultiplier,
 		}
 
-		// Use background context to ensure log completes even if request context cancelled
-		logCtx, logCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer logCancel()
-
-		if err := w.trackingService.LogRequestWithPlanTokensAsync(logCtx, requestInfo, tokenData); err != nil {
+		// Pass context.Background(): LogRequestWithPlanTokensAsync only uses
+		// the caller context to bound the queue-insertion attempt, and the
+		// queue uses non-blocking send. A short-lived context with a defer
+		// cancel here previously caused every queued write to fail with
+		// `context canceled` once the worker dequeued.
+		if err := w.trackingService.LogRequestWithPlanTokensAsync(context.Background(), requestInfo, tokenData); err != nil {
 			w.logger.Error("failed to log token usage for GPT-5 Pro response",
 				slog.String("response_id", w.job.ResponseID),
-				slog.Int("total_tokens", content.Usage.TotalTokens),
+				slog.Int("total_tokens", totalTokens),
 				slog.Int("plan_tokens", planTokens),
 				slog.Float64("multiplier", w.tokenMultiplier),
 				slog.String("error", err.Error()))
 		} else {
-			w.logger.Info("logged token usage for GPT-5 Pro response",
+			// "queued" — actual DB commit happens asynchronously in the
+			// request_tracking worker pool. Failures land at
+			// request_tracking/service.go:109 ("failed to insert request log
+			// with plan tokens"); look there if rows go missing despite this
+			// log appearing.
+			w.logger.Info("queued token usage log for GPT-5 Pro response",
 				slog.String("response_id", w.job.ResponseID),
-				slog.Int("prompt_tokens", content.Usage.PromptTokens),
-				slog.Int("completion_tokens", content.Usage.CompletionTokens),
-				slog.Int("total_tokens", content.Usage.TotalTokens),
+				slog.Int("prompt_tokens", promptTokens),
+				slog.Int("completion_tokens", completionTokens),
+				slog.Int("total_tokens", totalTokens),
 				slog.Int("plan_tokens", planTokens),
 				slog.Float64("multiplier", w.tokenMultiplier))
 		}

--- a/internal/background/types.go
+++ b/internal/background/types.go
@@ -65,10 +65,42 @@ type ResponseContent struct {
 }
 
 // UsageInfo represents token usage information.
+//
+// The OpenAI Responses API uses `input_tokens` / `output_tokens`; Chat
+// Completions uses `prompt_tokens` / `completion_tokens`. Pointer fields
+// distinguish "not present in payload" from "present and zero" — needed
+// because a `> 0` discriminator would silently fall through to the other
+// field name on a legitimate zero. Callers should use Prompt() / Completion().
 type UsageInfo struct {
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
-	TotalTokens      int `json:"total_tokens"`
+	PromptTokens     *int `json:"prompt_tokens,omitempty"`
+	CompletionTokens *int `json:"completion_tokens,omitempty"`
+	TotalTokens      int  `json:"total_tokens"`
+	InputTokens      *int `json:"input_tokens,omitempty"`
+	OutputTokens     *int `json:"output_tokens,omitempty"`
+}
+
+// Prompt returns the prompt/input token count from whichever field the
+// upstream API populated.
+func (u *UsageInfo) Prompt() int {
+	if u.PromptTokens != nil {
+		return *u.PromptTokens
+	}
+	if u.InputTokens != nil {
+		return *u.InputTokens
+	}
+	return 0
+}
+
+// Completion returns the completion/output token count from whichever field
+// the upstream API populated.
+func (u *UsageInfo) Completion() int {
+	if u.CompletionTokens != nil {
+		return *u.CompletionTokens
+	}
+	if u.OutputTokens != nil {
+		return *u.OutputTokens
+	}
+	return 0
 }
 
 // PollingJob represents a background polling job.

--- a/internal/request_tracking/service.go
+++ b/internal/request_tracking/service.go
@@ -23,20 +23,28 @@ type Service struct {
 	shutdown             chan struct{}
 	closed               atomic.Bool
 	logger               *logger.Logger
-	droppedRequestsTotal atomic.Int64 // NEW: Track dropped requests due to queue overflow
+	droppedRequestsTotal atomic.Int64 // Track dropped requests due to queue overflow.
+
+	// workerCtx is the parent context for every DB write. Cancelled by
+	// Shutdown when the bounded drain deadline is exceeded, which forces
+	// in-flight pgx calls to abort instead of holding shutdown open.
+	workerCtx    context.Context
+	workerCancel context.CancelFunc
 }
 
 type logRequest struct {
-	ctx  context.Context
 	info RequestInfo
 }
 
 func NewService(queries pgdb.Querier, logger *logger.Logger) *Service {
+	workerCtx, workerCancel := context.WithCancel(context.Background())
 	s := &Service{
-		queries:  queries,
-		logChan:  make(chan logRequest, config.AppConfig.RequestTrackingBufferSize),
-		shutdown: make(chan struct{}),
-		logger:   logger,
+		queries:      queries,
+		logChan:      make(chan logRequest, config.AppConfig.RequestTrackingBufferSize),
+		shutdown:     make(chan struct{}),
+		logger:       logger,
+		workerCtx:    workerCtx,
+		workerCancel: workerCancel,
 	}
 
 	// Worker pool with configurable number of workers.
@@ -143,8 +151,15 @@ func (s *Service) LogRequestAsync(ctx context.Context, info RequestInfo) error {
 		return fmt.Errorf("service shutting down")
 	}
 
+	// The caller's context governs ONLY the queue-insertion attempt. Once the
+	// request is queued, it must complete on its own clock — the caller's
+	// context is often cancelled long before a worker dequeues (e.g. the
+	// background polling worker uses a short-lived `context.WithTimeout` plus
+	// `defer cancel` purely to bound this call). Storing the caller's context
+	// on the queued request caused every GPT-5 Pro DB write to fail with
+	// `context canceled`, silently dropping the row and letting users bypass
+	// per-tier plan-token quotas. The worker creates its own fresh context.
 	logReq := logRequest{
-		ctx:  ctx,
 		info: info,
 	}
 
@@ -168,28 +183,51 @@ func (s *Service) LogRequestAsync(ctx context.Context, info RequestInfo) error {
 }
 
 // Shutdown gracefully shuts down the worker pool.
-func (s *Service) Shutdown() {
+//
+// Workers drain the queue under their normal per-write timeout. If the
+// supplied context expires before the drain completes, in-flight DB writes
+// are cancelled via workerCancel so this method always returns. Bounding
+// shutdown latency matters because each pgx call can otherwise consume the
+// full RequestTrackingTimeoutSeconds, and `worker_count × queue_depth × timeout`
+// can run into hours under DB trouble.
+//
+// logChan is intentionally NOT closed: LogRequestAsync checks `closed` and
+// then sends — closing the channel would create a send-on-closed-channel
+// panic race against any caller that has already passed the closed check.
+// The channel is unreferenced after Shutdown returns and is collected.
+func (s *Service) Shutdown(ctx context.Context) error {
 	s.closed.Store(true)
-
 	close(s.shutdown)
-	s.workerPool.Wait()
-	close(s.logChan)
+
+	done := make(chan struct{})
+	go func() {
+		s.workerPool.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		s.workerCancel()
+		return nil
+	case <-ctx.Done():
+		// Force in-flight DB writes to abort.
+		s.workerCancel()
+		<-done
+		return ctx.Err()
+	}
 }
 
-// handleLogRequest ensures each request has a reasonable timeout and then processes it.
+// handleLogRequest builds a fresh timeout context for the DB write derived
+// from workerCtx. The caller's context is deliberately not propagated — see
+// LogRequestAsync.
 func (s *Service) handleLogRequest(lr logRequest) {
-	ctx := lr.ctx
-
-	var cancel context.CancelFunc
-	if dl, ok := ctx.Deadline(); !ok || time.Until(dl) < time.Second {
-		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(config.AppConfig.RequestTrackingTimeoutSeconds)*time.Second)
-	}
+	ctx, cancel := context.WithTimeout(
+		s.workerCtx,
+		time.Duration(config.AppConfig.RequestTrackingTimeoutSeconds)*time.Second,
+	)
+	defer cancel()
 
 	s.processLogRequest(ctx, lr.info)
-
-	if cancel != nil {
-		cancel()
-	}
 }
 
 type RequestInfo struct {


### PR DESCRIPTION
Signed-off-by: Navendu Pottekkat <navendu@apache.org>

Count token usage for GPT pro model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service shutdown now enforces timeout limits to prevent indefinite hangs and service interruptions
  * Added dropped request counter to track and monitor queue overflow conditions

* **New Features**
  * Token tracking enhanced with support for input and output token types from API responses
  * Introduced plan-based weighted token logging for improved cost tracking and accounting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->