### PR TITLE
fix(zcash): settle payments in one transaction so expired invoices cannot double-grant

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -153,7 +153,7 @@ func main() {
 	if firebaseClient != nil {
 		zcashFirestoreClient = firebaseClient.GetFirestoreClient()
 	}
-	zcashService := zcash.NewService(db.Queries, zcashFirestoreClient, logger.WithComponent("zcash"))
+	zcashService := zcash.NewService(db.DB, db.Queries, zcashFirestoreClient, logger.WithComponent("zcash"))
 
 	// Initialize FAI payment service
 	faiService := fai.NewService(db.Queries, logger.WithComponent("fai"))

--- a/internal/storage/pg/queries/zcash_invoices.sql
+++ b/internal/storage/pg/queries/zcash_invoices.sql
@@ -7,6 +7,10 @@ INSERT INTO zcash_invoices (
 -- name: GetZcashInvoice :one
 SELECT * FROM zcash_invoices WHERE id = $1;
 
+-- name: GetZcashInvoiceForUpdate :one
+-- Row-locking read used to serialise concurrent payment callbacks for one invoice.
+SELECT * FROM zcash_invoices WHERE id = $1 FOR UPDATE;
+
 -- name: GetZcashInvoiceForUser :one
 SELECT * FROM zcash_invoices WHERE id = $1 AND user_id = $2;
 
@@ -20,15 +24,20 @@ UPDATE zcash_invoices
 SET status = $2, updated_at = NOW()
 WHERE id = $1;
 
--- name: UpdateZcashInvoiceToProcessing :exec
+-- name: UpdateZcashInvoiceToProcessing :execrows
+-- 'expired' is included because the expiry worker retires invoices after 24h while
+-- the payment backend may still be tracking a partial payment against them.
 UPDATE zcash_invoices
 SET status = 'processing', updated_at = NOW()
-WHERE id = $1 AND status = 'pending';
+WHERE id = $1 AND status IN ('pending', 'expired');
 
--- name: UpdateZcashInvoiceToPaid :exec
+-- name: UpdateZcashInvoiceToPaid :execrows
+-- Every non-paid status is accepted: a payment that lands after the invoice expired
+-- is still a payment, and the backend only calls back for invoices it still tracks.
+-- Returning the row count lets the caller refuse to commit a silent no-op.
 UPDATE zcash_invoices
 SET status = 'paid', paid_at = NOW(), updated_at = NOW()
-WHERE id = $1 AND status IN ('pending', 'processing');
+WHERE id = $1 AND status <> 'paid';
 
 -- name: GetExpiredPendingInvoices :many
 SELECT * FROM zcash_invoices

--- a/internal/storage/pg/sqlc/querier.go
+++ b/internal/storage/pg/sqlc/querier.go
@@ -70,6 +70,8 @@ type Querier interface {
 	GetUserPlanTokensToday(ctx context.Context, userID string) (int64, error)
 	GetUserTier(ctx context.Context, userID string) (GetUserTierRow, error)
 	GetZcashInvoice(ctx context.Context, id uuid.UUID) (ZcashInvoice, error)
+	// Row-locking read used to serialise concurrent payment callbacks for one invoice.
+	GetZcashInvoiceForUpdate(ctx context.Context, id uuid.UUID) (ZcashInvoice, error)
 	GetZcashInvoiceForUser(ctx context.Context, arg GetZcashInvoiceForUserParams) (ZcashInvoice, error)
 	GetZcashInvoicesByUserAndStatus(ctx context.Context, arg GetZcashInvoicesByUserAndStatusParams) ([]ZcashInvoice, error)
 	HasActiveDeepResearchRun(ctx context.Context, userID string) (bool, error)
@@ -86,8 +88,13 @@ type Querier interface {
 	UpdateTaskStatus(ctx context.Context, arg UpdateTaskStatusParams) error
 	UpdateZcashInvoiceStatus(ctx context.Context, arg UpdateZcashInvoiceStatusParams) error
 	UpdateZcashInvoiceToExpired(ctx context.Context, id uuid.UUID) error
-	UpdateZcashInvoiceToPaid(ctx context.Context, id uuid.UUID) error
-	UpdateZcashInvoiceToProcessing(ctx context.Context, id uuid.UUID) error
+	// Every non-paid status is accepted: a payment that lands after the invoice expired
+	// is still a payment, and the backend only calls back for invoices it still tracks.
+	// Returning the row count lets the caller refuse to commit a silent no-op.
+	UpdateZcashInvoiceToPaid(ctx context.Context, id uuid.UUID) (int64, error)
+	// 'expired' is included because the expiry worker retires invoices after 24h while
+	// the payment backend may still be tracking a partial payment against them.
+	UpdateZcashInvoiceToProcessing(ctx context.Context, id uuid.UUID) (int64, error)
 	UpsertEntitlement(ctx context.Context, arg UpsertEntitlementParams) error
 	// Grants or extends an entitlement. For same-tier renewals where the current
 	// subscription is still active (expires after invoice creation), extends from

--- a/internal/storage/pg/sqlc/zcash_invoices.sql.go
+++ b/internal/storage/pg/sqlc/zcash_invoices.sql.go
@@ -116,6 +116,30 @@ func (q *Queries) GetZcashInvoice(ctx context.Context, id uuid.UUID) (ZcashInvoi
 	return i, err
 }
 
+const getZcashInvoiceForUpdate = `-- name: GetZcashInvoiceForUpdate :one
+SELECT id, user_id, product_id, amount_zatoshis, zec_amount, price_usd, receiving_address, status, created_at, updated_at, paid_at FROM zcash_invoices WHERE id = $1 FOR UPDATE
+`
+
+// Row-locking read used to serialise concurrent payment callbacks for one invoice.
+func (q *Queries) GetZcashInvoiceForUpdate(ctx context.Context, id uuid.UUID) (ZcashInvoice, error) {
+	row := q.db.QueryRowContext(ctx, getZcashInvoiceForUpdate, id)
+	var i ZcashInvoice
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.ProductID,
+		&i.AmountZatoshis,
+		&i.ZecAmount,
+		&i.PriceUsd,
+		&i.ReceivingAddress,
+		&i.Status,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.PaidAt,
+	)
+	return i, err
+}
+
 const getZcashInvoiceForUser = `-- name: GetZcashInvoiceForUser :one
 SELECT id, user_id, product_id, amount_zatoshis, zec_amount, price_usd, receiving_address, status, created_at, updated_at, paid_at FROM zcash_invoices WHERE id = $1 AND user_id = $2
 `
@@ -217,24 +241,35 @@ func (q *Queries) UpdateZcashInvoiceToExpired(ctx context.Context, id uuid.UUID)
 	return err
 }
 
-const updateZcashInvoiceToPaid = `-- name: UpdateZcashInvoiceToPaid :exec
+const updateZcashInvoiceToPaid = `-- name: UpdateZcashInvoiceToPaid :execrows
 UPDATE zcash_invoices
 SET status = 'paid', paid_at = NOW(), updated_at = NOW()
-WHERE id = $1 AND status IN ('pending', 'processing')
+WHERE id = $1 AND status <> 'paid'
 `
 
-func (q *Queries) UpdateZcashInvoiceToPaid(ctx context.Context, id uuid.UUID) error {
-	_, err := q.db.ExecContext(ctx, updateZcashInvoiceToPaid, id)
-	return err
+// Every non-paid status is accepted: a payment that lands after the invoice expired
+// is still a payment, and the backend only calls back for invoices it still tracks.
+// Returning the row count lets the caller refuse to commit a silent no-op.
+func (q *Queries) UpdateZcashInvoiceToPaid(ctx context.Context, id uuid.UUID) (int64, error) {
+	result, err := q.db.ExecContext(ctx, updateZcashInvoiceToPaid, id)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
-const updateZcashInvoiceToProcessing = `-- name: UpdateZcashInvoiceToProcessing :exec
+const updateZcashInvoiceToProcessing = `-- name: UpdateZcashInvoiceToProcessing :execrows
 UPDATE zcash_invoices
 SET status = 'processing', updated_at = NOW()
-WHERE id = $1 AND status = 'pending'
+WHERE id = $1 AND status IN ('pending', 'expired')
 `
 
-func (q *Queries) UpdateZcashInvoiceToProcessing(ctx context.Context, id uuid.UUID) error {
-	_, err := q.db.ExecContext(ctx, updateZcashInvoiceToProcessing, id)
-	return err
+// 'expired' is included because the expiry worker retires invoices after 24h while
+// the payment backend may still be tracking a partial payment against them.
+func (q *Queries) UpdateZcashInvoiceToProcessing(ctx context.Context, id uuid.UUID) (int64, error) {
+	result, err := q.db.ExecContext(ctx, updateZcashInvoiceToProcessing, id)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }

--- a/internal/zcash/service.go
+++ b/internal/zcash/service.go
@@ -43,13 +43,17 @@ const (
 )
 
 type Service struct {
+	db              *sql.DB
 	queries         pgdb.Querier
 	logger          *logger.Logger
 	httpClient      *http.Client
 	firestoreClient *firestore.Client
 }
 
-func NewService(queries pgdb.Querier, firestoreClient *firestore.Client, logger *logger.Logger) *Service {
+// NewService needs the raw *sql.DB in addition to queries: settling a payment has to
+// grant the entitlement and mark the invoice paid in one transaction, which the
+// Querier interface alone cannot express.
+func NewService(db *sql.DB, queries pgdb.Querier, firestoreClient *firestore.Client, logger *logger.Logger) *Service {
 	client := &http.Client{
 		Timeout: 60 * time.Second,
 	}
@@ -64,6 +68,7 @@ func NewService(queries pgdb.Querier, firestoreClient *firestore.Client, logger 
 	}
 
 	return &Service{
+		db:              db,
 		queries:         queries,
 		logger:          logger,
 		httpClient:      client,
@@ -471,21 +476,22 @@ func (s *Service) HandlePaymentCallback(ctx context.Context, invoiceIDStr, statu
 		return fmt.Errorf("insufficient payment: got %d zatoshis, expected %d", accumulatedZatoshis, row.AmountZatoshis)
 	}
 
-	// For paid status: grant entitlement first, then mark invoice as paid.
-	// This ordering ensures retries work correctly - if grantEntitlement succeeds
-	// but UpdateZcashInvoiceToPaid fails, the retry will re-grant (idempotent upsert)
-	// and then mark as paid. The invoice only reaches "paid" status after entitlement
-	// is granted, so the idempotency check above is safe.
 	if status == "paid" {
-		if err := s.grantEntitlement(ctx, row); err != nil {
-			return fmt.Errorf("failed to grant entitlement: %w", err)
-		}
-		if err := s.queries.UpdateZcashInvoiceToPaid(ctx, invoiceID); err != nil {
-			return fmt.Errorf("failed to update invoice status: %w", err)
+		if err := s.settlePaidInvoice(ctx, invoiceID); err != nil {
+			return err
 		}
 	} else if status == "processing" {
-		if err := s.queries.UpdateZcashInvoiceToProcessing(ctx, invoiceID); err != nil {
+		affected, err := s.queries.UpdateZcashInvoiceToProcessing(ctx, invoiceID)
+		if err != nil {
 			return fmt.Errorf("failed to update invoice status: %w", err)
+		}
+		if affected == 0 {
+			// Already processing, or already settled by a concurrent delivery.
+			// Both are benign; the status is only ever moved forward.
+			s.logger.Debug("processing callback left invoice status unchanged",
+				"invoice_id", invoiceIDStr,
+				"status", row.Status,
+			)
 		}
 	}
 
@@ -503,7 +509,71 @@ func (s *Service) HandlePaymentCallback(ctx context.Context, invoiceIDStr, statu
 	return nil
 }
 
-func (s *Service) grantEntitlement(ctx context.Context, invoice pgdb.ZcashInvoice) error {
+// settlePaidInvoice grants the entitlement and marks the invoice paid in a single
+// transaction, re-reading the invoice under a row lock first.
+//
+// The two writes must land together. Granting outside a transaction - and against a
+// status update that could silently match no rows - meant an expired invoice took the
+// entitlement while its row stayed "expired". The idempotency check in the caller keys
+// on that status, so it never engaged, and because callbacks are delivered
+// at-least-once by design, each redelivery granted the user another full period.
+//
+// The FOR UPDATE read also serializes concurrent deliveries: the second one blocks
+// until the first commits, then observes "paid" rather than the status it read before
+// the backend verification round trip.
+func (s *Service) settlePaidInvoice(ctx context.Context, invoiceID uuid.UUID) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	qtx := pgdb.New(tx)
+
+	row, err := qtx.GetZcashInvoiceForUpdate(ctx, invoiceID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrInvoiceNotFound
+		}
+		return err
+	}
+
+	if row.Status == "paid" {
+		s.logger.Debug("invoice already paid, ignoring callback", "invoice_id", invoiceID.String())
+		return nil
+	}
+
+	if row.Status == "expired" {
+		s.logger.Warn("crediting a payment that arrived after the invoice expired",
+			"invoice_id", invoiceID.String(),
+			"user_id", row.UserID,
+			"created_at", row.CreatedAt,
+		)
+	}
+
+	if err := s.grantEntitlement(ctx, qtx, row); err != nil {
+		return fmt.Errorf("failed to grant entitlement: %w", err)
+	}
+
+	affected, err := qtx.UpdateZcashInvoiceToPaid(ctx, invoiceID)
+	if err != nil {
+		return fmt.Errorf("failed to update invoice status: %w", err)
+	}
+	if affected == 0 {
+		// Unreachable while we hold the row lock and have just seen a non-paid status.
+		// Fail rather than commit an entitlement against an invoice that stayed unpaid;
+		// the deferred rollback undoes the grant and the callback is retried.
+		return fmt.Errorf("invoice %s not marked paid from status %q", invoiceID, row.Status)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit payment: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Service) grantEntitlement(ctx context.Context, q pgdb.Querier, invoice pgdb.ZcashInvoice) error {
 	product := s.GetProduct(invoice.ProductID)
 	if product == nil {
 		return fmt.Errorf("unknown product: %s", invoice.ProductID)
@@ -515,7 +585,7 @@ func (s *Service) grantEntitlement(ctx context.Context, invoice pgdb.ZcashInvoic
 			Time:  time.Date(2099, 12, 31, 23, 59, 59, 0, time.UTC),
 			Valid: true,
 		}
-		err := s.queries.UpsertEntitlementWithTier(ctx, pgdb.UpsertEntitlementWithTierParams{
+		err := q.UpsertEntitlementWithTier(ctx, pgdb.UpsertEntitlementWithTierParams{
 			UserID:                invoice.UserID,
 			SubscriptionTier:      product.Tier,
 			SubscriptionExpiresAt: expiresAt,
@@ -549,7 +619,7 @@ func (s *Service) grantEntitlement(ctx context.Context, invoice pgdb.ZcashInvoic
 		durationDays = 30
 	}
 
-	err := s.queries.UpsertEntitlementWithExtension(ctx, pgdb.UpsertEntitlementWithExtensionParams{
+	err := q.UpsertEntitlementWithExtension(ctx, pgdb.UpsertEntitlementWithExtensionParams{
 		UserID:               invoice.UserID,
 		SubscriptionTier:     product.Tier,
 		BaseTime:             invoice.CreatedAt,

--- a/internal/zcash/service_integration_test.go
+++ b/internal/zcash/service_integration_test.go
@@ -1,0 +1,200 @@
+//go:build integration
+
+// Regression coverage for payment settlement. Requires a throwaway Postgres:
+//
+//	docker run -d --rm --name ep-zcash-test -e POSTGRES_PASSWORD=test \
+//	    -e POSTGRES_DB=eptest -p 55433:5432 postgres:16-alpine
+//	TEST_DATABASE_URL='postgres://postgres:test@localhost:55433/eptest?sslmode=disable' \
+//	    go test -tags integration -race ./internal/zcash/...
+package zcash
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eternisai/enchanted-proxy/internal/config"
+	"github.com/eternisai/enchanted-proxy/internal/logger"
+	"github.com/eternisai/enchanted-proxy/internal/storage/pg"
+	pgdb "github.com/eternisai/enchanted-proxy/internal/storage/pg/sqlc"
+	"github.com/google/uuid"
+)
+
+func newTestService(t *testing.T) (*Service, *sql.DB) {
+	t.Helper()
+
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+
+	db, err := sql.Open("postgres", url)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+	if err := pg.RunMigrations(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// GetProducts reads the debug multiplier; NewService reads the TLS flag.
+	if config.AppConfig == nil {
+		config.AppConfig = &config.Config{}
+	}
+
+	return NewService(db, pgdb.New(db), nil, logger.New(logger.Config{})), db
+}
+
+// seedInvoice inserts a monthly-pro invoice created `age` ago in the given status.
+func seedInvoice(t *testing.T, db *sql.DB, userID, status string, age time.Duration) (uuid.UUID, time.Time) {
+	t.Helper()
+
+	id := uuid.New()
+	var createdAt time.Time
+	err := db.QueryRow(`
+		INSERT INTO zcash_invoices (
+			id, user_id, product_id, amount_zatoshis, zec_amount,
+			price_usd, receiving_address, status, created_at, updated_at
+		) VALUES ($1, $2, $3, 4210372, 0.0421, 19.99, 'u1testaddress', $4, NOW() - $5::interval, NOW())
+		RETURNING created_at`,
+		id, userID, ProductMonthlyPro, status, age.String(),
+	).Scan(&createdAt)
+	if err != nil {
+		t.Fatalf("seed invoice: %v", err)
+	}
+	return id, createdAt
+}
+
+func readInvoice(t *testing.T, db *sql.DB, id uuid.UUID) (status string, paidAt *time.Time) {
+	t.Helper()
+	if err := db.QueryRow(`SELECT status, paid_at FROM zcash_invoices WHERE id = $1`, id).
+		Scan(&status, &paidAt); err != nil {
+		t.Fatalf("read invoice: %v", err)
+	}
+	return status, paidAt
+}
+
+func readExpiry(t *testing.T, db *sql.DB, userID string) time.Time {
+	t.Helper()
+	var expires time.Time
+	if err := db.QueryRow(`SELECT subscription_expires_at FROM entitlements WHERE user_id = $1`, userID).
+		Scan(&expires); err != nil {
+		t.Fatalf("read entitlement: %v", err)
+	}
+	return expires
+}
+
+// An invoice the expiry worker already retired still has to settle, and settle once.
+// Before the fix the status update matched no rows, so the row stayed "expired", the
+// caller's already-paid short circuit never engaged, and every redelivered callback
+// granted another 30 days.
+func TestSettlePaidInvoiceExpiredGrantsExactlyOnce(t *testing.T) {
+	svc, db := newTestService(t)
+	ctx := context.Background()
+	userID := "user-expired-" + uuid.NewString()
+
+	id, createdAt := seedInvoice(t, db, userID, "expired", 48*time.Hour)
+
+	if err := svc.settlePaidInvoice(ctx, id); err != nil {
+		t.Fatalf("first settle: %v", err)
+	}
+
+	status, paidAt := readInvoice(t, db, id)
+	if status != "paid" {
+		t.Fatalf("status after settle = %q, want \"paid\"", status)
+	}
+	if paidAt == nil {
+		t.Fatal("paid_at not set")
+	}
+
+	want := createdAt.Add(30 * 24 * time.Hour)
+	if got := readExpiry(t, db, userID); !got.Equal(want) {
+		t.Fatalf("expiry after settle = %v, want %v", got, want)
+	}
+
+	// Redelivery: at-least-once callbacks make this the normal case, not an edge case.
+	for i := range 3 {
+		if err := svc.settlePaidInvoice(ctx, id); err != nil {
+			t.Fatalf("redelivery %d: %v", i, err)
+		}
+	}
+
+	if got := readExpiry(t, db, userID); !got.Equal(want) {
+		t.Fatalf("expiry after 3 redeliveries = %v, want %v (double-granted by %v)",
+			got, want, got.Sub(want))
+	}
+}
+
+// Two deliveries racing past the caller's status read must not both grant. The row
+// lock in settlePaidInvoice is what serializes them.
+func TestSettlePaidInvoiceConcurrentDeliveriesGrantOnce(t *testing.T) {
+	svc, db := newTestService(t)
+	ctx := context.Background()
+	userID := "user-concurrent-" + uuid.NewString()
+
+	id, createdAt := seedInvoice(t, db, userID, "processing", time.Hour)
+
+	const deliveries = 4
+	var wg sync.WaitGroup
+	errs := make([]error, deliveries)
+	start := make(chan struct{})
+
+	for i := range deliveries {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs[i] = svc.settlePaidInvoice(ctx, id)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("delivery %d: %v", i, err)
+		}
+	}
+
+	want := createdAt.Add(30 * 24 * time.Hour)
+	if got := readExpiry(t, db, userID); !got.Equal(want) {
+		t.Fatalf("expiry after %d concurrent deliveries = %v, want %v (over-granted by %v)",
+			deliveries, got, want, got.Sub(want))
+	}
+}
+
+// A failed grant must not leave the invoice marked paid: the whole settlement rolls
+// back so the next delivery retries it. An unknown product makes grantEntitlement fail.
+func TestSettlePaidInvoiceRollsBackOnGrantFailure(t *testing.T) {
+	svc, db := newTestService(t)
+	ctx := context.Background()
+	userID := "user-rollback-" + uuid.NewString()
+
+	id, _ := seedInvoice(t, db, userID, "processing", time.Hour)
+	if _, err := db.Exec(`UPDATE zcash_invoices SET product_id = 'silo.nonexistent' WHERE id = $1`, id); err != nil {
+		t.Fatalf("set bogus product: %v", err)
+	}
+
+	if err := svc.settlePaidInvoice(ctx, id); err == nil {
+		t.Fatal("expected settle to fail for unknown product")
+	}
+
+	if status, paidAt := readInvoice(t, db, id); status != "processing" || paidAt != nil {
+		t.Fatalf("invoice = (%q, %v) after failed settle, want (\"processing\", <nil>)", status, paidAt)
+	}
+
+	var n int
+	if err := db.QueryRow(`SELECT count(*) FROM entitlements WHERE user_id = $1`, userID).Scan(&n); err != nil {
+		t.Fatalf("count entitlements: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("entitlement rows = %d after failed settle, want 0", n)
+	}
+}

--- a/internal/zcash/service_integration_test.go
+++ b/internal/zcash/service_integration_test.go
@@ -11,6 +11,7 @@ package zcash
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"os"
 	"sync"
 	"testing"
@@ -21,6 +22,7 @@ import (
 	"github.com/eternisai/enchanted-proxy/internal/storage/pg"
 	pgdb "github.com/eternisai/enchanted-proxy/internal/storage/pg/sqlc"
 	"github.com/google/uuid"
+	"github.com/lib/pq" // registers the driver here rather than relying on pg to do it
 )
 
 func newTestService(t *testing.T) (*Service, *sql.DB) {
@@ -170,12 +172,22 @@ func TestSettlePaidInvoiceConcurrentDeliveriesGrantOnce(t *testing.T) {
 	}
 }
 
-// A failed grant must not leave the invoice marked paid: the whole settlement rolls
-// back so the next delivery retries it. An unknown product makes grantEntitlement fail.
-func TestSettlePaidInvoiceRollsBackOnGrantFailure(t *testing.T) {
+func countEntitlements(t *testing.T, db *sql.DB, userID string) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(`SELECT count(*) FROM entitlements WHERE user_id = $1`, userID).Scan(&n); err != nil {
+		t.Fatalf("count entitlements: %v", err)
+	}
+	return n
+}
+
+// A grant that fails must not leave the invoice marked paid, so the next delivery
+// retries it. An unknown product fails grantEntitlement before it issues any
+// statement, so this covers the ordering only - see the test below for atomicity.
+func TestSettlePaidInvoiceLeavesInvoiceUnpaidWhenGrantFails(t *testing.T) {
 	svc, db := newTestService(t)
 	ctx := context.Background()
-	userID := "user-rollback-" + uuid.NewString()
+	userID := "user-grantfail-" + uuid.NewString()
 
 	id, _ := seedInvoice(t, db, userID, "processing", time.Hour)
 	if _, err := db.Exec(`UPDATE zcash_invoices SET product_id = 'silo.nonexistent' WHERE id = $1`, id); err != nil {
@@ -189,12 +201,51 @@ func TestSettlePaidInvoiceRollsBackOnGrantFailure(t *testing.T) {
 	if status, paidAt := readInvoice(t, db, id); status != "processing" || paidAt != nil {
 		t.Fatalf("invoice = (%q, %v) after failed settle, want (\"processing\", <nil>)", status, paidAt)
 	}
-
-	var n int
-	if err := db.QueryRow(`SELECT count(*) FROM entitlements WHERE user_id = $1`, userID).Scan(&n); err != nil {
-		t.Fatalf("count entitlements: %v", err)
-	}
-	if n != 0 {
+	if n := countEntitlements(t, db, userID); n != 0 {
 		t.Fatalf("entitlement rows = %d after failed settle, want 0", n)
+	}
+}
+
+// The atomicity guarantee: an entitlement upsert that has already succeeded must be
+// undone when a later statement in the settlement fails. Without the transaction the
+// user would keep a subscription period bought by an invoice that never settled.
+//
+// A trigger scoped to this user's invoice makes the status update fail after the
+// upsert has landed - the one ordering that cannot be produced from the Go side.
+func TestSettlePaidInvoiceRollsBackGrantWhenStatusUpdateFails(t *testing.T) {
+	svc, db := newTestService(t)
+	ctx := context.Background()
+	userID := "user-rollback-" + uuid.NewString()
+
+	id, _ := seedInvoice(t, db, userID, "processing", time.Hour)
+
+	if _, err := db.Exec(`
+		CREATE OR REPLACE FUNCTION test_fail_paid_update() RETURNS trigger AS $$
+		BEGIN RAISE EXCEPTION 'forced failure after grant'; END;
+		$$ LANGUAGE plpgsql`); err != nil {
+		t.Fatalf("create trigger function: %v", err)
+	}
+	// DDL takes no bind parameters, so the user id is quoted into the WHEN clause.
+	if _, err := db.Exec(fmt.Sprintf(`
+		CREATE TRIGGER test_fail_paid_update BEFORE UPDATE ON zcash_invoices
+		FOR EACH ROW WHEN (NEW.user_id = %s) EXECUTE FUNCTION test_fail_paid_update()`,
+		pq.QuoteLiteral(userID))); err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = db.Exec(`DROP TRIGGER IF EXISTS test_fail_paid_update ON zcash_invoices`)
+		_, _ = db.Exec(`DROP FUNCTION IF EXISTS test_fail_paid_update()`)
+	})
+
+	if err := svc.settlePaidInvoice(ctx, id); err == nil {
+		t.Fatal("expected settle to fail when the status update fails")
+	}
+
+	// grantEntitlement ran and its upsert succeeded; only the rollback removes it.
+	if n := countEntitlements(t, db, userID); n != 0 {
+		t.Fatalf("entitlement rows = %d after rollback, want 0 (grant was not undone)", n)
+	}
+	if status, paidAt := readInvoice(t, db, id); status != "processing" || paidAt != nil {
+		t.Fatalf("invoice = (%q, %v) after rollback, want (\"processing\", <nil>)", status, paidAt)
 	}
 }


### PR DESCRIPTION
## The bug

A payment that arrives after the expiry worker has retired an invoice grants the user an entitlement **on every redelivery**, extending the subscription by a full period each time.

Three things compound:

1. `UpdateZcashInvoiceToPaid` matched `status IN ('pending','processing')` — an `expired` row matched nothing.
2. sqlc `:exec` discards `RowsAffected`, so the no-op returned `nil` and read as success.
3. `grantEntitlement` ran *before* it, outside any transaction.

The row stays `expired` while the user holds the entitlement. `HandlePaymentCallback`'s idempotency guard is `if row.Status == "paid"`, so it never engages — and zcash-payment-backend delivers callbacks at-least-once by design (the delivery marker is written *after* the send), so redelivery is the normal case, not an edge case.

The comment above the old code claimed the grant-then-update ordering made retries safe. It was the thing that made them unsafe.

There was a second, narrower path to the same outcome: the status is read, then an HTTP round trip to the backend happens, then the grant. Two deliveries overlapping in that window both saw a non-paid status and both granted.

## Reproduction

Replaying the pre-fix statement sequence against the real schema, twice:

```
--- after delivery #1 ---     status=expired   granted=30 days
--- after delivery #2 ---     status=expired   granted=60 days
```

## The fix

`settlePaidInvoice` does the whole settlement in one transaction: `SELECT … FOR UPDATE` → re-check status → grant → mark paid → commit.

- **Concurrent deliveries serialize** on the row lock; the second unblocks, observes `paid`, and returns without granting.
- **A failed grant rolls back** instead of leaving a paid invoice with no entitlement. The old ordering could leave either half applied alone.
- **Status updates return row counts** (`:execrows`), so a silent no-op fails the settlement rather than committing a bare grant.
- **`UpdateZcashInvoiceToPaid` accepts any non-paid status**, and `ToProcessing` also accepts `expired`. A payment landing after expiry is still a payment, and the backend only calls back for invoices it still tracks.

`NewService` now takes the raw `*sql.DB` alongside `Querier` — the interface alone cannot express a transaction. Generated code regenerated with sqlc v1.30.0 (matching the existing file header); `go.mod`/`go.sum` untouched.

## Testing

`internal/zcash/service_integration_test.go`, behind the `integration` build tag following the existing convention in `internal/anonymizer`. Covers expired-then-redelivered-3x, 4 concurrent deliveries, and rollback on grant failure.

```
docker run -d --rm --name ep-zcash-test -e POSTGRES_PASSWORD=test \
    -e POSTGRES_DB=eptest -p 55433:5432 postgres:16-alpine
TEST_DATABASE_URL='postgres://postgres:test@localhost:55433/eptest?sslmode=disable' \
    go test -tags integration -race ./internal/zcash/...
```

All pass under `-race`. Also verified locally, since `Go CI (backend)` is currently `disabled_manually` and nothing will run automatically on this PR:

- `go build ./...`, `go vet`, `make test` — clean
- `golangci-lint` — no new findings (`service.go:17` gci and `:479` QF1003 pre-date this change; confirmed against a stash)
- dead-code gate — 46 pre-existing entries, byte-identical before and after, none in `zcash`

## Context

Found during the Ironwood (NU6.3) outage recovery. It never actually fired: the affected proxy row happened to be `processing` rather than `expired` when the recovery callback landed, so this path stayed untriggered — and therefore untested — until now.

## Not changed here

`UpsertEntitlementWithExtension` bases the period on `invoice.CreatedAt`, so an invoice paid two days late grants 30 days from *creation* and the user silently loses the delay. That is exactly what was hand-compensated during the Ironwood recovery.

This PR makes late settlement automatic, which makes that under-grant automatic too. Basing from settlement time instead would match the precedent already set, but it is a billing-policy call rather than a bug fix, so it is deliberately left alone. Happy to follow up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Zcash payment handling for expired invoices and repeated or concurrent payment callbacks.
  - Prevented duplicate entitlement grants during concurrent payment processing.
  - Ensured failed entitlement updates roll back related invoice changes.
  - Added safer transactional settlement and status handling for invoice payments.

- **Tests**
  - Added integration coverage for single settlement, concurrent deliveries, expired invoices, and rollback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->