### PR TITLE
chore: reroute models due to deprecation

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -102,28 +102,21 @@ model_router:
     - name: Tinfoil
       model: llama3-3-70b
 
-  # GLM 4.7 - via NEAR AI (0.6× multiplier) - Keep on actual 4.7
-  - name: zai-org/GLM-4.7
-    aliases:
-    - zhipu/glm-4.7
-    - z-ai/glm-4.7
-    - glm-4.7
-    - zai-org/GLM-4.6
-    - z-ai/glm-4.6
-    - glm-4.6
-    token_multiplier: 0.75
-    providers:
-    - name: NEAR AI
-      model: z-ai/glm-5.2
-
-  # GLM 5 - via NEAR AI (0.6× multiplier) - Available when explicitly requested
+  # GLM 5 - via NEAR AI (0.75× multiplier) - Available when explicitly requested
   - name: zai-org/GLM-5-FP8
     aliases:
+    - glm-4.6
+    - glm-4.7
     - glm-5
     - glm5
+    - z-ai/glm-4.6
+    - z-ai/glm-4.7
     - z-ai/glm-5
     - z-ai/glm-5.2
+    - zai-org/GLM-4.6
+    - zai-org/GLM-4.7
     - zai-org/glm-5.0
+    - zhipu/glm-4.7
     token_multiplier: 0.75
     providers:
     # Temporary reroute due to GLM issues

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -62,32 +62,35 @@ model_router:
     base_url: https://openrouter.ai/api/v1
 
   models:
-  # Kimi K2.6 - Free & Pro - via Tinfoil (0.75× multiplier) - NEW DEFAULT
-  - name: moonshot/kimi-k2
+  # Kimi K3 - Free & Pro - via Tinfoil (0.75× multiplier) - NEW DEFAULT
+  - name: moonshot/kimi-k3
     aliases:
     - kimi-k2
+    - kimi-k2-6
     - kimi-2.5
+    - kimi-k3
     - kimi
+    - moonshot/kimi-k2
     token_multiplier: 0.75
     providers:
     - name: Tinfoil
-      model: kimi-k2-6
+      model: kimi-k3
 
-  # DeepSeek V4 Pro - Free & Pro - via Tinfoil (0.75× multiplier)
-  - name: deepseek-ai/DeepSeek-V4-Pro
-    aliases:
-    - deepseek/deepseek-v4-pro
-    - deepseek-v4-pro
-    - deepseek-v4
-    - deepseek/deepseek-r1-0528
-    - deepseek-r1-0528
-    - deepseek-r1
-    token_multiplier: 0.75
-    providers:
-    - name: Tinfoil
-      model: deepseek-v4-pro
-      probe:
-        max_tokens: 400
+  ## DeepSeek V4 Pro - Free & Pro - via Tinfoil (0.75× multiplier)
+  #- name: deepseek-ai/DeepSeek-V4-Pro
+  #  aliases:
+  #  - deepseek/deepseek-v4-pro
+  #  - deepseek-v4-pro
+  #  - deepseek-v4
+  #  - deepseek/deepseek-r1-0528
+  #  - deepseek-r1-0528
+  #  - deepseek-r1
+  #  token_multiplier: 0.75
+  #  providers:
+  #  - name: Tinfoil
+  #    model: deepseek-v4-pro
+  #    probe:
+  #      max_tokens: 400
 
   # Llama 3.3 70B - Free & Pro - via Tinfoil (0.75× multiplier)
   - name: meta-llama/Llama-3.3-70B
@@ -110,9 +113,8 @@ model_router:
     - glm-4.6
     token_multiplier: 0.75
     providers:
-    # Temporary reroute due to GLM issues
-    - name: Tinfoil
-      model: kimi-k2-6
+    - name: NEAR AI
+      model: z-ai/glm-5.2
 
   # GLM 5 - via NEAR AI (0.6× multiplier) - Available when explicitly requested
   - name: zai-org/GLM-5-FP8
@@ -120,12 +122,13 @@ model_router:
     - glm-5
     - glm5
     - z-ai/glm-5
+    - z-ai/glm-5.2
     - zai-org/glm-5.0
     token_multiplier: 0.75
     providers:
     # Temporary reroute due to GLM issues
-    - name: Tinfoil
-      model: kimi-k2-6
+    - name: NEAR AI
+      model: z-ai/glm-5.2
 
   # Qwen3 30B A3B - Free & Pro - via NEAR AI (0.04× multiplier, fallback model)
   - name: Qwen/Qwen3-30B-A3B-Instruct-2507

--- a/internal/tiers/tiers.go
+++ b/internal/tiers/tiers.go
@@ -78,8 +78,8 @@ var Configs = map[Tier]Config{
 		// AllowedModels uses canonical model names only (from config.yaml).
 		// Aliases are resolved to canonical names by the middleware before this check.
 		AllowedModels: []string{
-			"moonshot/kimi-k2",                        // Kimi K2 (0.75×)
-			"deepseek-ai/DeepSeek-V4-Pro",             // DeepSeek V4 Pro (0.75×)
+			//"deepseek-ai/DeepSeek-V4-Pro",             // DeepSeek V4 Pro (0.75×)
+			"moonshot/kimi-k3",                        // Kimi K3 (0.75×)
 			"meta-llama/Llama-3.3-70B",                // Llama 3.3 70B (1×)
 			"zai-org/GLM-5-FP8",                       // GLM 5 (0.6×)
 			"dphn/Dolphin-Mistral-24B-Venice-Edition", // Dolphin Mistral (0.5×, uncensored)

--- a/internal/tiers/tiers.go
+++ b/internal/tiers/tiers.go
@@ -81,7 +81,7 @@ var Configs = map[Tier]Config{
 			//"deepseek-ai/DeepSeek-V4-Pro",             // DeepSeek V4 Pro (0.75×)
 			"moonshot/kimi-k3",                        // Kimi K3 (0.75×)
 			"meta-llama/Llama-3.3-70B",                // Llama 3.3 70B (1×)
-			"zai-org/GLM-5-FP8",                       // GLM 5 (0.6×)
+			"zai-org/GLM-5-FP8",                       // GLM 5 (0.75×)
 			"dphn/Dolphin-Mistral-24B-Venice-Edition", // Dolphin Mistral (0.5×, uncensored)
 			"Qwen/Qwen3-30B-A3B-Instruct-2507",        // Qwen3 30B (0.04×)
 		},


### PR DESCRIPTION
* Kimi K2.5 -> Kimi K3 on Tinfoil (due to Kimi K2.5 deprecation, new default)
* GLM-4, GLM-5 -> GLM-5.2 on NEAR AI
* DeepSeek-v4 removed due to deprecation on all CC providers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kimi K3 as the default Kimi model, with Kimi K2 and K3 aliases available.
  * Expanded GLM model availability with additional GLM aliases and the latest GLM-5 configuration.
* **Changes**
  * Updated provider routing for Kimi and GLM requests.
  * DeepSeek V4 Pro is no longer available.
  * The free tier now includes Kimi K3 and excludes DeepSeek V4 Pro.
  * Updated GLM-5 pricing to reflect current rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->