### PR TITLE
chore: reroute models

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -62,35 +62,33 @@ model_router:
     base_url: https://openrouter.ai/api/v1
 
   models:
-  # Kimi K3 - Free & Pro - via Tinfoil (0.75× multiplier) - NEW DEFAULT
-  - name: moonshot/kimi-k3
+  # Kimi K2.6 - Free & Pro - via NEAR AI (0.75× multiplier) - NEW DEFAULT
+  - name: moonshot/kimi-k2
     aliases:
     - kimi-k2
     - kimi-k2-6
     - kimi-2.5
-    - kimi-k3
     - kimi
     - moonshot/kimi-k2
     token_multiplier: 0.75
     providers:
-    - name: Tinfoil
-      model: kimi-k3
+    - name: NEAR AI
+      model: moonshotai/kimi-k2.6
 
-  ## DeepSeek V4 Pro - Free & Pro - via Tinfoil (0.75× multiplier)
-  #- name: deepseek-ai/DeepSeek-V4-Pro
-  #  aliases:
-  #  - deepseek/deepseek-v4-pro
-  #  - deepseek-v4-pro
-  #  - deepseek-v4
-  #  - deepseek/deepseek-r1-0528
-  #  - deepseek-r1-0528
-  #  - deepseek-r1
-  #  token_multiplier: 0.75
-  #  providers:
-  #  - name: Tinfoil
-  #    model: deepseek-v4-pro
-  #    probe:
-  #      max_tokens: 400
+  # DeepSeek V4 Pro - Free & Pro - temporary reroute to DeepSeek V4 Flash via NEAR AI (0.75× multiplier)
+  - name: deepseek-ai/DeepSeek-V4-Pro
+    aliases:
+    - deepseek/deepseek-v4-pro
+    - deepseek-v4-pro
+    - deepseek-v4
+    - deepseek/deepseek-r1-0528
+    - deepseek-r1-0528
+    - deepseek-r1
+    token_multiplier: 0.75
+    providers:
+    # Temporary reroute before full deprecation as unavailable at upstream providers
+    - name: NEAR AI
+      model: deepseek-ai/DeepSeek-V4-Flash
 
   # Llama 3.3 70B - Free & Pro - via Tinfoil (0.75× multiplier)
   - name: meta-llama/Llama-3.3-70B

--- a/internal/tiers/tiers.go
+++ b/internal/tiers/tiers.go
@@ -78,8 +78,8 @@ var Configs = map[Tier]Config{
 		// AllowedModels uses canonical model names only (from config.yaml).
 		// Aliases are resolved to canonical names by the middleware before this check.
 		AllowedModels: []string{
-			//"deepseek-ai/DeepSeek-V4-Pro",             // DeepSeek V4 Pro (0.75×)
-			"moonshot/kimi-k3",                        // Kimi K3 (0.75×)
+			"moonshot/kimi-k2",                        // Kimi K2 (0.75×)
+			"deepseek-ai/DeepSeek-V4-Pro",             // DeepSeek V4 Pro (0.75×)
 			"meta-llama/Llama-3.3-70B",                // Llama 3.3 70B (1×)
 			"zai-org/GLM-5-FP8",                       // GLM 5 (0.75×)
 			"dphn/Dolphin-Mistral-24B-Venice-Edition", // Dolphin Mistral (0.5×, uncensored)


### PR DESCRIPTION
    Kimi K3 (Tinfoil) -> Kimi K2.6 (NEAR AI attested third-party TEE)
    DeepSeek V4 Pro -> DeepSeek V4 Flash (NEAR AI TEE)

    Kimi K3 is unrouted due to slowness and significant price increase on Tinfoil.
    DeepSeek V4 needs extra work to remove from the UI/app, temporarily re-enabled
    with rerouting to avoid breakage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DeepSeek V4 Pro to the available model options through NEAR AI.
  * Updated the default Kimi model to Kimi K2.6 through NEAR AI.

* **Updates**
  * Updated free-tier model availability to include DeepSeek V4 Pro and Kimi K2.
  * Retained existing Kimi model aliases and usage multiplier settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->