### PR TITLE
feat(probe): persist probe state across restarts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ make sqlc         # Regenerate SQL after editing queries/
 | Quota tracking | `internal/request_tracking/service.go` |
 | Stream management | `internal/streaming/manager.go` |
 | Background polling | `internal/background/polling_manager.go` |
+| Model health probes | `internal/probe/worker.go` ([state](docs/llm-prober-state.md)) |
 | E2EE encryption | `internal/messaging/encryption.go` |
 | Key sharing (WS) | `internal/keyshare/handlers.go` |
 | Deep research | `internal/deepr/handlers.go` |
@@ -139,6 +140,8 @@ make test                          # All tests
 ```
 
 ## Deployment
+
+**LLM prober**: deployed separately from the enclave (`cmd/llm-prober`). Its probe state persists to a PersistentVolume; the volume, `fsGroup`, and `strategy: Recreate` requirements are in [`docs/llm-prober-state.md`](docs/llm-prober-state.md).
 
 **TEE config**: `deploy/enclaver.yaml` - egress allowlist for providers. For the full enclave architecture (networking, egress filtering, DNS, process supervision), see [`docs/tee-architecture.md`](docs/tee-architecture.md). Check there first if you hit unexplained networking or connection issues.
 

--- a/cmd/llm-prober/Dockerfile
+++ b/cmd/llm-prober/Dockerfile
@@ -32,10 +32,12 @@ RUN apk add --no-cache ca-certificates && \
 COPY --chown=prober:prober config/config.yaml /etc/enchanted-proxy/config.yaml
 ENV CONFIG_FILE=/etc/enchanted-proxy/config.yaml
 
-# Probe state survives restarts so an endpoint that was failing before a restart
-# still announces its recovery. Mount a PersistentVolume here to carry that state
-# across rescheduling; without one it only survives in-place container restarts,
-# and if the directory is unwritable the prober logs a warning and runs stateless.
+# Probe state lives here, so an endpoint that was failing before a restart still
+# announces its recovery. Mount a volume at this path: a restarted container in
+# Kubernetes is a new container built from the image, so a database written to
+# the container's own filesystem is discarded on every restart and the prober
+# would always start fresh. If the directory is unwritable the prober logs a
+# warning and runs without persistence rather than failing to start.
 # See docs/llm-prober-state.md for the volume requirements.
 RUN mkdir -p /var/lib/llm-prober && chown prober:prober /var/lib/llm-prober
 ENV LLM_PROBER_STATE_DB=/var/lib/llm-prober/state.db

--- a/cmd/llm-prober/Dockerfile
+++ b/cmd/llm-prober/Dockerfile
@@ -32,6 +32,14 @@ RUN apk add --no-cache ca-certificates && \
 COPY --chown=prober:prober config/config.yaml /etc/enchanted-proxy/config.yaml
 ENV CONFIG_FILE=/etc/enchanted-proxy/config.yaml
 
+# Probe state survives restarts so an endpoint that was failing before a restart
+# still announces its recovery. Mount a PersistentVolume here to carry that state
+# across rescheduling; without one it only survives in-place container restarts,
+# and if the directory is unwritable the prober logs a warning and runs stateless.
+# See docs/llm-prober-state.md for the volume requirements.
+RUN mkdir -p /var/lib/llm-prober && chown prober:prober /var/lib/llm-prober
+ENV LLM_PROBER_STATE_DB=/var/lib/llm-prober/state.db
+
 COPY --chown=prober:prober --from=builder /app/llm-prober /usr/local/bin/llm-prober
 EXPOSE 9090
 USER prober

--- a/cmd/llm-prober/main.go
+++ b/cmd/llm-prober/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"log"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -27,7 +28,7 @@ func main() {
 	stateDB := flag.String("state-db", "", "path to the persistent probe state database (default: LLM_PROBER_STATE_DB env; empty disables persistence)")
 	stateFlush := flag.Duration("state-flush-interval", 5*time.Minute, "how often pending probe timestamps are coalesced into a single write")
 	dumpState := flag.Bool("dump-state", false, "print the contents of the probe state database as JSON and exit")
-	debugAddr := flag.String("debug-listen", "127.0.0.1:9091", "loopback address serving /debug/state; empty disables it")
+	debugAddr := flag.String("debug-listen", "127.0.0.1:9091", "loopback address serving /debug/state; must be a loopback host; empty disables it")
 	flag.Parse()
 
 	// Resolve config file path: flag > env > default.
@@ -137,8 +138,19 @@ func main() {
 	// readable by anything that can reach the pod. The state view is only ever
 	// consumed by an operator already inside the container, so it is bound to
 	// loopback and reachable by nothing else.
+	// The address is not taken on trust. /debug/state is unauthenticated, so a
+	// value like ":9091" or "0.0.0.0:9091" would undo the isolation the separate
+	// listener exists to provide. A non-loopback address disables the server
+	// rather than failing startup, matching how the rest of this degrades.
+	debugListen := *debugAddr
+	if debugListen != "" && !isLoopbackAddr(debugListen) {
+		appLog.Warn("refusing to serve /debug/state on a non-loopback address; state introspection disabled",
+			slog.String("addr", debugListen))
+		debugListen = ""
+	}
+
 	var debugServer *http.Server
-	if *debugAddr != "" {
+	if debugListen != "" {
 		debugMux := http.NewServeMux()
 		// Reads through the already-open database: bbolt holds its file lock for
 		// the lifetime of this process, so nothing outside it can open the
@@ -156,14 +168,14 @@ func main() {
 		})
 
 		debugServer = &http.Server{
-			Addr:              *debugAddr,
+			Addr:              debugListen,
 			Handler:           debugMux,
 			ReadHeaderTimeout: 10 * time.Second,
 			IdleTimeout:       60 * time.Second,
 		}
 
 		go func() {
-			appLog.Info("debug server listening", slog.String("addr", *debugAddr))
+			appLog.Info("debug server listening", slog.String("addr", debugListen))
 			if err := debugServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 				// Not fatal: losing state introspection must not stop probing.
 				appLog.Warn("debug server error", slog.String("error", err.Error()))
@@ -191,4 +203,21 @@ func main() {
 	}
 
 	appLog.Info("llm-prober stopped")
+}
+
+// isLoopbackAddr reports whether addr binds the loopback interface only.
+//
+// A missing host (":9091") binds every interface, so it is rejected along with
+// any routable address. Only IP literals are accepted, plus "localhost", so the
+// decision never depends on name resolution.
+func isLoopbackAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil || host == "" {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }

--- a/cmd/llm-prober/main.go
+++ b/cmd/llm-prober/main.go
@@ -114,6 +114,20 @@ func main() {
 		}
 		w.WriteHeader(http.StatusOK)
 	})
+	// Reads the state through the already-open database. bbolt holds its file
+	// lock for the lifetime of this process, so nothing outside it can open the
+	// database while the prober runs — the live view has to be served from here.
+	mux.HandleFunc("/debug/state", func(w http.ResponseWriter, r *http.Request) {
+		records, err := probeService.StateSnapshot()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := probe.WriteDump(w, records); err != nil {
+			appLog.Warn("failed to write state snapshot", slog.String("error", err.Error()))
+		}
+	})
 
 	server := &http.Server{
 		Addr:              *listenAddr,

--- a/cmd/llm-prober/main.go
+++ b/cmd/llm-prober/main.go
@@ -24,6 +24,9 @@ func main() {
 	listenAddr := flag.String("listen", ":9090", "address for metrics server")
 	logLevel := flag.String("log-level", "info", "log level (debug, info, warn, error)")
 	logFormat := flag.String("log-format", "", "log format (json or text)")
+	stateDB := flag.String("state-db", "", "path to the persistent probe state database (default: LLM_PROBER_STATE_DB env; empty disables persistence)")
+	stateFlush := flag.Duration("state-flush-interval", 5*time.Minute, "how often pending probe timestamps are coalesced into a single write")
+	dumpState := flag.Bool("dump-state", false, "print the contents of the probe state database as JSON and exit")
 	flag.Parse()
 
 	// Resolve config file path: flag > env > default.
@@ -33,6 +36,21 @@ func main() {
 		if cfgPath == "" {
 			cfgPath = "config/config.yaml"
 		}
+	}
+
+	// Resolve state database path: flag > env > disabled.
+	statePath := *stateDB
+	if statePath == "" {
+		statePath = os.Getenv("LLM_PROBER_STATE_DB")
+	}
+
+	// -dump-state is an operator tool: read the database and exit without
+	// touching config, the network, or the running prober's state.
+	if *dumpState {
+		if err := probe.DumpState(statePath, os.Stdout); err != nil {
+			log.Fatalf("failed to dump probe state: %v", err)
+		}
+		return
 	}
 
 	// Initialize logger.
@@ -76,7 +94,11 @@ func main() {
 		appLogger.WithComponent("probe"),
 		router,
 		cfg.ModelRouterConfig.Models,
-		os.Getenv("LLM_PROBER_SLACK_WEBHOOK_URL"),
+		probe.Options{
+			SlackWebhookURL:    os.Getenv("LLM_PROBER_SLACK_WEBHOOK_URL"),
+			StateDBPath:        statePath,
+			StateFlushInterval: *stateFlush,
+		},
 	)
 
 	// Start metrics HTTP server.

--- a/cmd/llm-prober/main.go
+++ b/cmd/llm-prober/main.go
@@ -27,6 +27,7 @@ func main() {
 	stateDB := flag.String("state-db", "", "path to the persistent probe state database (default: LLM_PROBER_STATE_DB env; empty disables persistence)")
 	stateFlush := flag.Duration("state-flush-interval", 5*time.Minute, "how often pending probe timestamps are coalesced into a single write")
 	dumpState := flag.Bool("dump-state", false, "print the contents of the probe state database as JSON and exit")
+	debugAddr := flag.String("debug-listen", "127.0.0.1:9091", "loopback address serving /debug/state; empty disables it")
 	flag.Parse()
 
 	// Resolve config file path: flag > env > default.
@@ -114,21 +115,6 @@ func main() {
 		}
 		w.WriteHeader(http.StatusOK)
 	})
-	// Reads the state through the already-open database. bbolt holds its file
-	// lock for the lifetime of this process, so nothing outside it can open the
-	// database while the prober runs — the live view has to be served from here.
-	mux.HandleFunc("/debug/state", func(w http.ResponseWriter, r *http.Request) {
-		records, err := probeService.StateSnapshot()
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusServiceUnavailable)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		if err := probe.WriteDump(w, records); err != nil {
-			appLog.Warn("failed to write state snapshot", slog.String("error", err.Error()))
-		}
-	})
-
 	server := &http.Server{
 		Addr:              *listenAddr,
 		Handler:           mux,
@@ -143,6 +129,48 @@ func main() {
 		}
 	}()
 
+	// Start the debug server.
+	//
+	// This is deliberately a second listener rather than another route on the
+	// metrics mux. The metrics port is bound on all interfaces so Prometheus can
+	// scrape it, and it carries no authentication, so a route added there is
+	// readable by anything that can reach the pod. The state view is only ever
+	// consumed by an operator already inside the container, so it is bound to
+	// loopback and reachable by nothing else.
+	var debugServer *http.Server
+	if *debugAddr != "" {
+		debugMux := http.NewServeMux()
+		// Reads through the already-open database: bbolt holds its file lock for
+		// the lifetime of this process, so nothing outside it can open the
+		// database while the prober runs.
+		debugMux.HandleFunc("/debug/state", func(w http.ResponseWriter, r *http.Request) {
+			records, err := probeService.StateSnapshot()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusServiceUnavailable)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if err := probe.WriteDump(w, records); err != nil {
+				appLog.Warn("failed to write state snapshot", slog.String("error", err.Error()))
+			}
+		})
+
+		debugServer = &http.Server{
+			Addr:              *debugAddr,
+			Handler:           debugMux,
+			ReadHeaderTimeout: 10 * time.Second,
+			IdleTimeout:       60 * time.Second,
+		}
+
+		go func() {
+			appLog.Info("debug server listening", slog.String("addr", *debugAddr))
+			if err := debugServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				// Not fatal: losing state introspection must not stop probing.
+				appLog.Warn("debug server error", slog.String("error", err.Error()))
+			}
+		}()
+	}
+
 	// Wait for shutdown signal.
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
@@ -155,6 +183,11 @@ func main() {
 	defer cancel()
 	if err := server.Shutdown(ctx); err != nil {
 		appLog.Error("metrics server shutdown error", slog.String("error", err.Error()))
+	}
+	if debugServer != nil {
+		if err := debugServer.Shutdown(ctx); err != nil {
+			appLog.Error("debug server shutdown error", slog.String("error", err.Error()))
+		}
 	}
 
 	appLog.Info("llm-prober stopped")

--- a/cmd/llm-prober/main_test.go
+++ b/cmd/llm-prober/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import "testing"
+
+func TestIsLoopbackAddr(t *testing.T) {
+	tests := []struct {
+		addr string
+		want bool
+	}{
+		// Accepted: the loopback interface only.
+		{"127.0.0.1:9091", true},
+		{"127.0.0.1:0", true},
+		{"127.9.9.9:9091", true}, // all of 127.0.0.0/8 is loopback
+		{"[::1]:9091", true},
+		{"localhost:9091", true},
+
+		// Rejected: reachable from outside the pod.
+		{":9091", false},        // every interface
+		{"0.0.0.0:9091", false}, // every interface, explicitly
+		{"[::]:9091", false},
+		{"10.3.115.94:9091", false}, // a pod IP
+		{"192.168.1.9:9091", false},
+		{"example.com:9091", false}, // never resolved, so never accepted
+
+		// Rejected: malformed.
+		{"127.0.0.1", false}, // no port
+		{"", false},
+		{"garbage", false},
+	}
+
+	for _, tt := range tests {
+		if got := isLoopbackAddr(tt.addr); got != tt.want {
+			t.Errorf("isLoopbackAddr(%q) = %v, want %v", tt.addr, got, tt.want)
+		}
+	}
+}

--- a/docs/llm-prober-state.md
+++ b/docs/llm-prober-state.md
@@ -148,4 +148,6 @@ Two further couplings are easy to miss when editing those manifests:
   applied.
 
 The prober runs a single replica by design; running two against one volume is not
-supported (the second gets no persistence).
+supported (the second gets no persistence). A StatefulSet creates its volumes as
+part of creating a pod, so an environment that pins the prober to zero replicas
+provisions no PVC and no PV — production is the only one that gets storage.

--- a/docs/llm-prober-state.md
+++ b/docs/llm-prober-state.md
@@ -118,18 +118,34 @@ diagnosed.
 
 ## Deployment requirements
 
-The manifests live in the `gitops-apps` repository. Three things matter:
+The manifests live in the `gitops-apps` repository, at
+`apps/enchanted-proxy/workloads/llm-prober/`. The prober is a **StatefulSet**
+rather than a Deployment, for three reasons that all trace back to the lock bbolt
+holds on the database file:
 
-- **Mount a PersistentVolume at `/var/lib/llm-prober`.** Without one the state
-  lives in the container's writable layer: it survives an in-place container
-  restart but not rescheduling.
-- **Set `securityContext.fsGroup`.** The container runs as the non-root `prober`
-  user, and a volume mounted `root:root` is not writable by it — the prober would
-  warn and run stateless.
-- **Use `strategy: Recreate`, not `RollingUpdate`.** bbolt takes an exclusive file
-  lock. On a rolling update over a ReadWriteOnce volume the incoming pod finds the
-  lock held by the outgoing one, waits 10s, then gives up and runs stateless for
-  its entire lifetime.
+- **A volume at `/var/lib/llm-prober`,** provisioned by a `volumeClaimTemplate`
+  (1Gi — the smallest EBS volume available; the database is tens of KiB). Without
+  a volume the state lives in the container's writable layer: it survives an
+  in-place container restart, but not rescheduling.
+- **`securityContext.fsGroup: 101`,** matching the `prober` group in the image
+  (the container runs as uid 100, gid 101). A freshly provisioned volume is
+  mounted `root:root`, which that user cannot write — the prober would warn and
+  run stateless.
+- **An update strategy that never overlaps two pods.** A StatefulSet rolling
+  update is ordered: the outgoing pod is fully terminated before the incoming one
+  is created. A Deployment cannot promise that over a ReadWriteOnce volume — with
+  `maxSurge > 0` the incoming pod finds the lock held, waits 10s, then gives up
+  and runs stateless for its entire lifetime.
 
-The prober has a single replica by design; running two against one volume is not
+Two further couplings are easy to miss when editing those manifests:
+
+- The `VaultStaticSecret` for `proxy-api` lists the prober in
+  `rolloutRestartTargets`. That is what restarts it when a rotated API key lands
+  in Vault — the exact scenario this state exists to serve — so the entry must
+  name `kind: StatefulSet`.
+- The per-cluster `PatchTransformer` that stamps version labels selects on
+  `kind`, so it must target `StatefulSet` too, or the labels silently stop being
+  applied.
+
+The prober runs a single replica by design; running two against one volume is not
 supported (the second gets no persistence).

--- a/docs/llm-prober-state.md
+++ b/docs/llm-prober-state.md
@@ -127,6 +127,11 @@ narrow that. Since the only consumer of the state view is an operator already
 inside the container, binding it to loopback means nothing outside the pod can
 reach it at all.
 
+`-debug-listen` only accepts a loopback host — a `127.0.0.0/8` or `::1` literal,
+or `localhost`. Anything else, including `:9091` and `0.0.0.0:9091`, is refused
+with a warning and leaves the endpoint switched off, so the isolation cannot be
+widened by a flag change alone.
+
 `-dump-state` is for a prober that is stopped, or for a copy of its volume. Run
 against a running prober it fails with a message pointing at the endpoint rather
 than hanging on the lock.

--- a/docs/llm-prober-state.md
+++ b/docs/llm-prober-state.md
@@ -1,0 +1,135 @@
+# LLM Prober Persistent State
+
+The prober records the health state of each probe target on disk so it survives a
+restart. Everything here is optional: with no state database the prober behaves
+exactly as it did before persistence existed.
+
+## Why
+
+Each probe worker has two stages. The initial stage discovers a state it does not
+yet know, and a first success there is silent by design — announcing "healthy" for
+every endpoint on every startup would be noise. The normal-operation stage then
+notifies on each transition.
+
+Without persistence, every restart re-enters the initial stage. That loses the
+recovery notification in exactly the case where it matters most: an endpoint fails,
+the prober alerts, an operator rotates the offending API key and restarts the
+workload, the next probe succeeds — and the success is swallowed as an initial
+state. Nobody is told the outage ended.
+
+With persistence, a target that has a stored state skips the initial stage and
+resumes in the normal-operation stage, so that first success is a transition and
+gets announced. The state it resumed *into* is not re-announced; the process that
+recorded it already did that.
+
+## What is stored
+
+One record per probe target, updated in place. Probe attempts are not journalled.
+
+| Field | Purpose |
+|---|---|
+| `provider`, `canonical_model`, `base_url`, `effective_model` | target identity (also the key) |
+| `state` | `healthy` or `failing` |
+| `state_changed_at` | when that state was entered |
+| `last_probe_at` | when the target was last probed |
+
+The store is [bbolt](https://github.com/etcd-io/bbolt): a single file, pure Go
+(the prober builds `CGO_ENABLED=0`), transactional, and a negligible addition to
+the module's dependencies.
+
+### Identity
+
+The key is the full endpoint tuple — provider name, canonical model name,
+normalized base URL, and upstream model name. This mirrors the
+`(base_url, effective_model)` pair that `NewProbeService` already deduplicates
+workers on, plus the two names that label the target's metrics, so a record maps
+to exactly one worker.
+
+A config change that reroutes a model to a different provider or upstream name
+therefore starts that target fresh rather than inheriting the state of the
+endpoint it replaced. That is intended: it is a different endpoint. The old record
+is simply never looked up again — there is no garbage collection.
+
+### Write volume
+
+State transitions are written through immediately, in their own transaction. They
+are rare, and one lost to an ungraceful shutdown would resurrect the bug this
+exists to fix.
+
+Last-probe timestamps are held in memory and coalesced: one flusher writes every
+pending timestamp in a single transaction per flush interval (default 5m), and on
+graceful shutdown. Write volume is therefore flat — roughly 290 transactions a day
+regardless of how many endpoints are configured or how fast they are being
+retried. Writing each timestamp through instead would cost ~1,250 transactions a
+day at steady state and ~18,700 during an outage that puts every target on its
+retry interval.
+
+An ungraceful kill can lose up to one flush interval of timestamps. The cost is at
+most one early re-probe per target; notification correctness is unaffected, since
+that rides on the state transitions, which are never buffered.
+
+## Startup behaviour
+
+On startup each worker with a valid record:
+
+1. adopts the stored state and publishes its health gauge immediately, so
+   `model_router_probe_healthy` has no gap while the first probe runs;
+2. skips the initial stage;
+3. schedules its first probe at `last_probe_at + interval` — the probe interval
+   when healthy, the retry interval when failing — plus the usual jitter.
+
+If that moment has already passed, the first probe runs immediately (still
+jittered). Measuring from the last probe rather than the state change is what stops
+a crash-looping pod from re-probing every endpoint on every restart;
+`state_changed_at` is the fallback for a record written before any timestamp was
+flushed.
+
+## Failure handling
+
+Nothing about the state is allowed to stop the prober from monitoring. A missing
+file, a missing directory, a read-only volume, a lock held by an outgoing pod, or
+an unreadable database each produce a **warning** and the prober runs without
+persistence.
+
+Individual records that cannot be trusted — undecodable, an unrecognized schema
+version, an unknown state, an incomplete identity, a missing or future-dated
+timestamp, or an identity that disagrees with the key it is stored under — are
+logged and skipped. Those targets start as if never probed. Invalid records are
+ignored, never deleted.
+
+## Configuration
+
+| Flag | Env | Default | Meaning |
+|---|---|---|---|
+| `-state-db` | `LLM_PROBER_STATE_DB` | `/var/lib/llm-prober/state.db` (set in the image) | Database path; empty disables persistence |
+| `-state-flush-interval` | — | `5m` | How often pending timestamps are coalesced |
+| `-dump-state` | — | — | Print the database as JSON and exit |
+
+`-dump-state` opens the database read-only, so it is safe to run against a live
+prober:
+
+```bash
+kubectl exec deploy/llm-prober -- llm-prober -dump-state | jq '.[] | select(.valid) | {key, state: .state.state}'
+```
+
+Records that would be skipped at load time are included in the dump, flagged with
+`valid: false` and the reason, so a store the prober is silently ignoring can be
+diagnosed.
+
+## Deployment requirements
+
+The manifests live in the `gitops-apps` repository. Three things matter:
+
+- **Mount a PersistentVolume at `/var/lib/llm-prober`.** Without one the state
+  lives in the container's writable layer: it survives an in-place container
+  restart but not rescheduling.
+- **Set `securityContext.fsGroup`.** The container runs as the non-root `prober`
+  user, and a volume mounted `root:root` is not writable by it — the prober would
+  warn and run stateless.
+- **Use `strategy: Recreate`, not `RollingUpdate`.** bbolt takes an exclusive file
+  lock. On a rolling update over a ReadWriteOnce volume the incoming pod finds the
+  lock held by the outgoing one, waits 10s, then gives up and runs stateless for
+  its entire lifetime.
+
+The prober has a single replica by design; running two against one volume is not
+supported (the second gets no persistence).

--- a/docs/llm-prober-state.md
+++ b/docs/llm-prober-state.md
@@ -104,19 +104,28 @@ ignored, never deleted.
 | `-state-db` | `LLM_PROBER_STATE_DB` | `/var/lib/llm-prober/state.db` (set in the image) | Database path; empty disables persistence |
 | `-state-flush-interval` | — | `5m` | How often pending timestamps are coalesced |
 | `-dump-state` | — | — | Print a **stopped** prober's database as JSON and exit |
+| `-debug-listen` | — | `127.0.0.1:9091` | Loopback address serving `/debug/state`; empty disables it |
 
-To read a **running** prober, use the `/debug/state` endpoint on the metrics
-port. bbolt holds an exclusive lock on the file for as long as the prober has it
-open, and a read-only open still needs a shared lock, so no second process can
-read the database while the prober runs — the live view has to be served from
-inside the process:
+To read a **running** prober, use the `/debug/state` endpoint. bbolt holds an
+exclusive lock on the file for as long as the prober has it open, and a
+read-only open still needs a shared lock, so no second process can read the
+database while the prober runs — the live view has to be served from inside the
+process:
 
 ```bash
-kubectl exec sts/llm-prober -- wget -qO- localhost:9090/debug/state \
+kubectl exec sts/llm-prober -- wget -qO- localhost:9091/debug/state \
   | jq '.[] | select(.valid) | {key, state: .state.state}'
 ```
 
 It returns 503 with the reason when persistence is disabled or unavailable.
+
+The endpoint is on its own listener bound to loopback, not on the metrics port.
+The metrics port is bound on all interfaces so Prometheus can scrape it and
+carries no authentication, so anything able to reach the pod can read what is
+served there; the namespace has no NetworkPolicy or Istio AuthorizationPolicy to
+narrow that. Since the only consumer of the state view is an operator already
+inside the container, binding it to loopback means nothing outside the pod can
+reach it at all.
 
 `-dump-state` is for a prober that is stopped, or for a copy of its volume. Run
 against a running prober it fails with a message pointing at the endpoint rather

--- a/docs/llm-prober-state.md
+++ b/docs/llm-prober-state.md
@@ -103,16 +103,26 @@ ignored, never deleted.
 |---|---|---|---|
 | `-state-db` | `LLM_PROBER_STATE_DB` | `/var/lib/llm-prober/state.db` (set in the image) | Database path; empty disables persistence |
 | `-state-flush-interval` | — | `5m` | How often pending timestamps are coalesced |
-| `-dump-state` | — | — | Print the database as JSON and exit |
+| `-dump-state` | — | — | Print a **stopped** prober's database as JSON and exit |
 
-`-dump-state` opens the database read-only, so it is safe to run against a live
-prober:
+To read a **running** prober, use the `/debug/state` endpoint on the metrics
+port. bbolt holds an exclusive lock on the file for as long as the prober has it
+open, and a read-only open still needs a shared lock, so no second process can
+read the database while the prober runs — the live view has to be served from
+inside the process:
 
 ```bash
-kubectl exec deploy/llm-prober -- llm-prober -dump-state | jq '.[] | select(.valid) | {key, state: .state.state}'
+kubectl exec sts/llm-prober -- wget -qO- localhost:9090/debug/state \
+  | jq '.[] | select(.valid) | {key, state: .state.state}'
 ```
 
-Records that would be skipped at load time are included in the dump, flagged with
+It returns 503 with the reason when persistence is disabled or unavailable.
+
+`-dump-state` is for a prober that is stopped, or for a copy of its volume. Run
+against a running prober it fails with a message pointing at the endpoint rather
+than hanging on the lock.
+
+Both views include records that would be skipped at load time, flagged with
 `valid: false` and the reason, so a store the prober is silently ignoring can be
 diagnosed.
 
@@ -123,19 +133,27 @@ The manifests live in the `gitops-apps` repository, at
 rather than a Deployment, for three reasons that all trace back to the lock bbolt
 holds on the database file:
 
-- **A volume at `/var/lib/llm-prober`,** provisioned by a `volumeClaimTemplate`
-  (1Gi — the smallest EBS volume available; the database is tens of KiB). Without
-  a volume the state lives in the container's writable layer: it survives an
-  in-place container restart, but not rescheduling.
+- **A volume at `/var/lib/llm-prober`,** provisioned by a `volumeClaimTemplates`
+  entry (1Gi — the smallest EBS volume available; the database is tens of KiB).
+  The volume is not optional in Kubernetes: a restarted container is a *new*
+  container built from the image, so anything written to the container's own
+  filesystem is gone. Without a volume the state does not survive even a crash
+  loop, and the prober simply starts fresh every time.
 - **`securityContext.fsGroup: 101`,** matching the `prober` group in the image
   (the container runs as uid 100, gid 101). A freshly provisioned volume is
   mounted `root:root`, which that user cannot write — the prober would warn and
   run stateless.
 - **An update strategy that never overlaps two pods.** A StatefulSet rolling
   update is ordered: the outgoing pod is fully terminated before the incoming one
-  is created. A Deployment cannot promise that over a ReadWriteOnce volume — with
-  `maxSurge > 0` the incoming pod finds the lock held, waits 10s, then gives up
-  and runs stateless for its entire lifetime.
+  is created. The workload previously ran as a Deployment with
+  `maxSurge: 33%, maxUnavailable: 0`, which creates the replacement first — over
+  a ReadWriteOnce volume the incoming pod finds the lock held, waits 10s, gives
+  up, and runs stateless for its entire lifetime. A Deployment with
+  `strategy.type: Recreate` would also terminate before creating, so the ordering
+  alone does not require a StatefulSet; the StatefulSet is what additionally
+  gives a stable pod identity and a per-pod volume from `volumeClaimTemplates`,
+  which is what makes "exactly one holder of this database" structural rather
+  than a property of the rollout settings.
 
 Two further couplings are easy to miss when editing those manifests:
 
@@ -148,6 +166,12 @@ Two further couplings are easy to miss when editing those manifests:
   applied.
 
 The prober runs a single replica by design; running two against one volume is not
-supported (the second gets no persistence). A StatefulSet creates its volumes as
-part of creating a pod, so an environment that pins the prober to zero replicas
-provisions no PVC and no PV — production is the only one that gets storage.
+supported (the second gets no persistence).
+
+A StatefulSet creates its volumes as part of creating a pod, so an environment
+that has *never* run the prober above zero replicas has no PVC and no PV —
+production is the only one that provisions storage. Scaling an existing prober
+down to zero is a different case: its PVC is kept, because
+`persistentVolumeClaimRetentionPolicy.whenScaled` is set to `Retain` (also the
+default) precisely so the state is still there when it scales back up. Deleting
+storage requires deleting the PVC.

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stripe/stripe-go/v84 v84.0.0
 	github.com/vektah/gqlparser/v2 v2.5.30
+	go.etcd.io/bbolt v1.4.3
 	go.temporal.io/sdk v1.37.0
 	golang.org/x/crypto v0.45.0
 	golang.org/x/oauth2 v0.32.0

--- a/go.sum
+++ b/go.sum
@@ -398,6 +398,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=
+go.etcd.io/bbolt v1.4.3/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/detectors/gcp v1.38.0 h1:ZoYbqX7OaA/TAikspPl3ozPI6iY6LiIY9I8cUfm+pJs=

--- a/internal/probe/service.go
+++ b/internal/probe/service.go
@@ -20,9 +20,25 @@ import (
 type ProbeService struct {
 	logger   *logger.Logger
 	slack    *slackNotifier
+	state    *stateStore
 	wg       sync.WaitGroup
 	shutdown chan struct{}
 	cancel   context.CancelFunc
+}
+
+// Options holds the optional, deployment-specific settings of the probe service.
+type Options struct {
+	// SlackWebhookURL enables Slack notifications on probe state changes.
+	SlackWebhookURL string
+
+	// StateDBPath is the on-disk location of the persistent probe state database.
+	// Empty disables persistence; workers then start with no prior state, exactly
+	// as they did before persistence existed.
+	StateDBPath string
+
+	// StateFlushInterval is how often pending last-probe timestamps are coalesced
+	// into a single write. Zero selects defaultStateFlushInterval.
+	StateFlushInterval time.Duration
 }
 
 // probeTarget holds deduplicated probe configuration, pairing the resolved
@@ -39,17 +55,24 @@ type probeTarget struct {
 // config declaration order so the first canonical name encountered wins for metrics.
 // Responses API endpoints are routed to /responses with dedicated request/response
 // handling (buildResponsesProbeRequestBody / parseResponsesAPIResponse).
-func NewProbeService(logger *logger.Logger, router *routing.ModelRouter, models []config.ModelConfig, slackWebhookURL string) *ProbeService {
+//
+// When persistent state is configured and a target has a valid record, the worker
+// resumes from it instead of re-establishing an initial state, which is what
+// preserves recovery notifications across restarts.
+func NewProbeService(logger *logger.Logger, router *routing.ModelRouter, models []config.ModelConfig, opts Options) *ProbeService {
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &ProbeService{
 		logger:   logger,
 		shutdown: make(chan struct{}),
 		cancel:   cancel,
 	}
-	if slackWebhookURL != "" {
-		s.slack = newSlackNotifier(slackWebhookURL)
+	if opts.SlackWebhookURL != "" {
+		s.slack = newSlackNotifier(opts.SlackWebhookURL)
 		logger.Info("slack notifications enabled")
 	}
+
+	s.state = openStateStore(opts.StateDBPath, opts.StateFlushInterval, logger)
+	restored := s.state.Load()
 
 	routes := router.GetRoutes()
 
@@ -124,7 +147,21 @@ func NewProbeService(logger *logger.Logger, router *routing.ModelRouter, models 
 	}
 
 	// Create workers from deduplicated, ordered targets.
+	resumed := 0
 	for _, target := range targets {
+		key := newTargetKey(
+			target.providerName,
+			target.canonicalModel,
+			target.provider.BaseURL,
+			target.provider.Model,
+		)
+
+		var state *targetState
+		if record, ok := restored[key]; ok {
+			state = &record
+			resumed++
+		}
+
 		w := &probeWorker{
 			service:  s,
 			ctx:      ctx,
@@ -132,6 +169,8 @@ func NewProbeService(logger *logger.Logger, router *routing.ModelRouter, models 
 			model:    target.canonicalModel,
 			endpoint: target.provider,
 			probe:    target.probe,
+			key:      key,
+			restored: state,
 			client: &http.Client{
 				Timeout: probeHTTPTimeout,
 				Transport: &http.Transport{
@@ -153,7 +192,8 @@ func NewProbeService(logger *logger.Logger, router *routing.ModelRouter, models 
 
 	logger.Info("probe service started",
 		slog.Int("workers", len(targets)),
-		slog.Int("duplicates_skipped", duplicatesSkipped))
+		slog.Int("duplicates_skipped", duplicatesSkipped),
+		slog.Int("resumed_from_state", resumed))
 
 	return s
 }
@@ -177,5 +217,7 @@ func (s *ProbeService) Shutdown() {
 	s.cancel()
 	close(s.shutdown)
 	s.wg.Wait()
+	// Closed after the workers stop so the final flush captures every timestamp.
+	s.state.Close()
 	s.logger.Info("probe service stopped")
 }

--- a/internal/probe/state.go
+++ b/internal/probe/state.go
@@ -34,10 +34,10 @@ const (
 	// stateBucket holds one key per probe target (see targetKey.storageKey).
 	stateBucket = "probe_state"
 
-	// stateOpenTimeout bounds how long we wait for bbolt's file lock. A rolling
-	// restart on an RWO volume can briefly overlap two pods; rather than block
-	// startup indefinitely we give up and run without persistence.
-	stateOpenTimeout = 10 * time.Second
+	// stateDebugPath serves the running prober's state. bbolt's lock is held for
+	// the lifetime of the process that opened the database, so a second process
+	// cannot read it — the live view has to come from inside.
+	stateDebugPath = "/debug/state"
 
 	// defaultStateFlushInterval is how often pending last-probe timestamps are
 	// coalesced into a single write transaction.
@@ -48,6 +48,12 @@ const (
 	// writer and the reader of the volume.
 	stateFutureSkew = 5 * time.Minute
 )
+
+// stateOpenTimeout bounds how long we wait for bbolt's file lock. A rolling
+// restart on an RWO volume can briefly overlap two pods; rather than block
+// startup indefinitely we give up and run without persistence. It is a variable
+// only so tests do not have to sit out the full wait.
+var stateOpenTimeout = 10 * time.Second
 
 // healthState is the persisted health of a probe target.
 type healthState string

--- a/internal/probe/state.go
+++ b/internal/probe/state.go
@@ -1,0 +1,476 @@
+package probe
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/eternisai/enchanted-proxy/internal/logger"
+)
+
+// Persistent probe state lets the prober survive restarts without losing track of
+// which endpoints were already known to be failing. Without it, every restart —
+// including the deliberate ones used to roll a rotated API key — re-enters the
+// initial-state stage, where the first success is silent by design, so the
+// recovery notification for the very outage that prompted the restart is lost.
+//
+// The store keeps exactly one record per probe target: its current state, when
+// that state was entered, and when it was last probed. Probe attempts are not
+// journalled; the record is updated in place.
+const (
+	// stateSchemaVersion is stamped into every record. Records carrying any other
+	// version are ignored on load rather than migrated — the state is a cache that
+	// can always be rebuilt by probing, so there is nothing worth migrating.
+	stateSchemaVersion = 1
+
+	// stateBucket holds one key per probe target (see targetKey.storageKey).
+	stateBucket = "probe_state"
+
+	// stateOpenTimeout bounds how long we wait for bbolt's file lock. A rolling
+	// restart on an RWO volume can briefly overlap two pods; rather than block
+	// startup indefinitely we give up and run without persistence.
+	stateOpenTimeout = 10 * time.Second
+
+	// defaultStateFlushInterval is how often pending last-probe timestamps are
+	// coalesced into a single write transaction.
+	defaultStateFlushInterval = 5 * time.Minute
+
+	// stateFutureSkew is how far ahead of now a persisted timestamp may sit before
+	// the record is treated as corrupt. Allows for modest clock skew between the
+	// writer and the reader of the volume.
+	stateFutureSkew = 5 * time.Minute
+)
+
+// healthState is the persisted health of a probe target.
+type healthState string
+
+const (
+	stateHealthy healthState = "healthy"
+	stateFailing healthState = "failing"
+)
+
+// valid reports whether s is a state this version knows how to act on.
+func (s healthState) valid() bool {
+	return s == stateHealthy || s == stateFailing
+}
+
+// healthStateFor maps a boolean health flag to its persisted representation.
+func healthStateFor(healthy bool) healthState {
+	if healthy {
+		return stateHealthy
+	}
+	return stateFailing
+}
+
+// targetKey identifies a probe target across restarts. It mirrors the worker
+// identity established in NewProbeService: the (base_url, effective_model) pair
+// that workers are deduplicated on, plus the provider and canonical model names
+// that label the target's metrics.
+//
+// Using the full tuple means a config change that reroutes a model to a different
+// provider or upstream model name starts that target fresh instead of inheriting
+// the state of the endpoint it replaced — the old record is simply never looked
+// up again. That is the intended trade-off: it is a different endpoint.
+type targetKey struct {
+	Provider       string
+	CanonicalModel string
+	BaseURL        string
+	EffectiveModel string
+}
+
+// newTargetKey builds a key, normalizing the base URL the same way the worker
+// dedup key does so a trailing slash in config does not orphan existing state.
+func newTargetKey(provider, canonicalModel, baseURL, effectiveModel string) targetKey {
+	return targetKey{
+		Provider:       provider,
+		CanonicalModel: canonicalModel,
+		BaseURL:        strings.TrimRight(baseURL, "/"),
+		EffectiveModel: effectiveModel,
+	}
+}
+
+// storageKey renders the key for use as a bbolt key. NUL is used as the separator
+// because it cannot occur in any of the components, so the encoding is injective.
+func (k targetKey) storageKey() []byte {
+	return []byte(strings.Join([]string{
+		k.Provider, k.CanonicalModel, k.BaseURL, k.EffectiveModel,
+	}, "\x00"))
+}
+
+// logAttrs returns the key's components as log attributes.
+func (k targetKey) logAttrs() []any {
+	return []any{
+		slog.String("provider", k.Provider),
+		slog.String("model", k.CanonicalModel),
+		slog.String("base_url", k.BaseURL),
+		slog.String("effective_model", k.EffectiveModel),
+	}
+}
+
+// targetState is the persisted record for one probe target. The identity fields
+// duplicate the key so a record can be validated against the key it was stored
+// under, and so a raw dump of the store is self-describing.
+type targetState struct {
+	Version        int         `json:"v"`
+	Provider       string      `json:"provider"`
+	CanonicalModel string      `json:"canonical_model"`
+	BaseURL        string      `json:"base_url"`
+	EffectiveModel string      `json:"effective_model"`
+	State          healthState `json:"state"`
+	StateChangedAt time.Time   `json:"state_changed_at"`
+	LastProbeAt    time.Time   `json:"last_probe_at,omitzero"`
+}
+
+// key reconstructs the target key from the record's identity fields.
+func (s targetState) key() targetKey {
+	return targetKey{
+		Provider:       s.Provider,
+		CanonicalModel: s.CanonicalModel,
+		BaseURL:        s.BaseURL,
+		EffectiveModel: s.EffectiveModel,
+	}
+}
+
+// validate reports why a record cannot be trusted, or nil if it can. Callers
+// discard invalid records rather than failing: a target with no usable state
+// simply starts as if it had never been probed.
+func (s targetState) validate(now time.Time) error {
+	if s.Version != stateSchemaVersion {
+		return fmt.Errorf("unsupported schema version %d (want %d)", s.Version, stateSchemaVersion)
+	}
+	if !s.State.valid() {
+		return fmt.Errorf("unknown state %q", s.State)
+	}
+	if s.Provider == "" || s.CanonicalModel == "" || s.BaseURL == "" || s.EffectiveModel == "" {
+		return errors.New("incomplete target identity")
+	}
+	if s.StateChangedAt.IsZero() {
+		return errors.New("missing state_changed_at")
+	}
+	if s.StateChangedAt.After(now.Add(stateFutureSkew)) {
+		return fmt.Errorf("state_changed_at %s is in the future", s.StateChangedAt.Format(time.RFC3339))
+	}
+	if !s.LastProbeAt.IsZero() && s.LastProbeAt.After(now.Add(stateFutureSkew)) {
+		return fmt.Errorf("last_probe_at %s is in the future", s.LastProbeAt.Format(time.RFC3339))
+	}
+	return nil
+}
+
+// stateStore persists probe state to a bbolt database on disk.
+//
+// State transitions are written through immediately, in their own transaction:
+// they are rare, and losing one to an ungraceful shutdown would resurrect the
+// very bug this store exists to fix. Last-probe timestamps are held in memory and
+// coalesced into a single transaction per flush interval, so write volume stays
+// flat regardless of how many endpoints are configured or how fast they are being
+// retried.
+//
+// A nil *stateStore is a fully functional no-op, so callers never need to branch
+// on whether persistence is configured.
+type stateStore struct {
+	db     *bolt.DB
+	logger *logger.Logger
+
+	mu    sync.Mutex
+	dirty map[string]time.Time // storage key -> pending last-probe timestamp
+
+	flushInterval time.Duration
+	stop          chan struct{}
+	done          chan struct{}
+}
+
+// openStateStore opens (creating if absent) the state database at path.
+//
+// Every failure mode here is non-fatal: a missing file, a missing directory, a
+// read-only volume, a lock held by an outgoing pod, or an unreadable database all
+// produce a warning and a nil store, and the prober runs exactly as it did before
+// persistence existed. Losing restart continuity is never a reason to stop
+// monitoring.
+func openStateStore(path string, flushInterval time.Duration, log *logger.Logger) *stateStore {
+	if path == "" {
+		log.Info("persistent probe state disabled (no state database path configured)")
+		return nil
+	}
+
+	if dir := filepath.Dir(path); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			log.Warn("persistent probe state unavailable: cannot create state directory",
+				slog.String("path", path),
+				slog.String("error", err.Error()))
+			return nil
+		}
+	}
+
+	existed := true
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		existed = false
+	}
+
+	db, err := bolt.Open(path, 0o600, &bolt.Options{Timeout: stateOpenTimeout})
+	if err != nil {
+		log.Warn("persistent probe state unavailable: cannot open state database",
+			slog.String("path", path),
+			slog.String("error", err.Error()))
+		return nil
+	}
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists([]byte(stateBucket))
+		return err
+	}); err != nil {
+		log.Warn("persistent probe state unavailable: cannot initialize state database",
+			slog.String("path", path),
+			slog.String("error", err.Error()))
+		_ = db.Close()
+		return nil
+	}
+
+	if flushInterval <= 0 {
+		flushInterval = defaultStateFlushInterval
+	}
+
+	s := &stateStore{
+		db:            db,
+		logger:        log,
+		dirty:         make(map[string]time.Time),
+		flushInterval: flushInterval,
+		stop:          make(chan struct{}),
+		done:          make(chan struct{}),
+	}
+
+	if existed {
+		log.Info("opened persistent probe state",
+			slog.String("path", path),
+			slog.Duration("flush_interval", flushInterval))
+	} else {
+		log.Warn("no persistent probe state found, starting fresh",
+			slog.String("path", path))
+	}
+
+	go s.flushLoop()
+
+	return s
+}
+
+// Load returns every valid record in the store, keyed by target key. Records that
+// fail to decode, carry an unknown schema version, or disagree with the key they
+// are stored under are skipped with a warning: garbage is ignored, never removed,
+// and never fatal.
+func (s *stateStore) Load() map[targetKey]targetState {
+	if s == nil {
+		return nil
+	}
+
+	now := time.Now()
+	loaded := make(map[targetKey]targetState)
+	invalid := 0
+
+	err := s.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(stateBucket))
+		if bucket == nil {
+			return nil
+		}
+		return bucket.ForEach(func(k, v []byte) error {
+			var record targetState
+			if err := json.Unmarshal(v, &record); err != nil {
+				invalid++
+				s.logger.Warn("ignoring unreadable probe state record",
+					slog.String("key", strings.ReplaceAll(string(k), "\x00", "|")),
+					slog.String("error", err.Error()))
+				return nil
+			}
+			if err := record.validate(now); err != nil {
+				invalid++
+				s.logger.Warn("ignoring invalid probe state record",
+					slog.String("key", strings.ReplaceAll(string(k), "\x00", "|")),
+					slog.String("error", err.Error()))
+				return nil
+			}
+			// The identity inside the record must agree with the key it lives
+			// under; a mismatch means the file was written by something else.
+			key := record.key()
+			if string(key.storageKey()) != string(k) {
+				invalid++
+				s.logger.Warn("ignoring probe state record whose identity does not match its key",
+					slog.String("key", strings.ReplaceAll(string(k), "\x00", "|")))
+				return nil
+			}
+			loaded[key] = record
+			return nil
+		})
+	})
+	if err != nil {
+		s.logger.Warn("failed to read persistent probe state, starting fresh",
+			slog.String("error", err.Error()))
+		return nil
+	}
+
+	s.logger.Info("loaded persistent probe state",
+		slog.Int("records", len(loaded)),
+		slog.Int("ignored", invalid))
+
+	return loaded
+}
+
+// RecordStateChange durably persists a health transition for key. The write goes
+// to disk immediately rather than waiting for the next flush, because a state
+// change lost to an ungraceful shutdown is exactly the failure this store exists
+// to prevent. Any pending last-probe timestamp for the target is folded into the
+// same write.
+func (s *stateStore) RecordStateChange(key targetKey, state healthState, at time.Time) {
+	if s == nil {
+		return
+	}
+
+	record := targetState{
+		Version:        stateSchemaVersion,
+		Provider:       key.Provider,
+		CanonicalModel: key.CanonicalModel,
+		BaseURL:        key.BaseURL,
+		EffectiveModel: key.EffectiveModel,
+		State:          state,
+		StateChangedAt: at,
+		LastProbeAt:    at,
+	}
+
+	storageKey := key.storageKey()
+
+	s.mu.Lock()
+	delete(s.dirty, string(storageKey))
+	s.mu.Unlock()
+
+	if err := s.put(record); err != nil {
+		s.logger.Warn("failed to persist probe state change",
+			append(key.logAttrs(), slog.String("error", err.Error()))...)
+		return
+	}
+
+	s.logger.Debug("persisted probe state change",
+		append(key.logAttrs(), slog.String("state", string(state)))...)
+}
+
+// RecordProbe notes that key was probed at the given time. The timestamp is held
+// in memory and written by the next flush; see the type comment for why this is
+// not written through.
+func (s *stateStore) RecordProbe(key targetKey, at time.Time) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.dirty[string(key.storageKey())] = at
+	s.mu.Unlock()
+}
+
+// put writes a single record in its own transaction.
+func (s *stateStore) put(record targetState) error {
+	encoded, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("encoding probe state: %w", err)
+	}
+	return s.db.Update(func(tx *bolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists([]byte(stateBucket))
+		if err != nil {
+			return err
+		}
+		return bucket.Put(record.key().storageKey(), encoded)
+	})
+}
+
+// Flush writes all pending last-probe timestamps in a single transaction.
+//
+// A timestamp is only applied to a target that already has a valid record: the
+// first thing a worker persists is its state, so a missing record means the
+// target has not established a state yet and there is nothing for a bare
+// timestamp to attach to.
+func (s *stateStore) Flush() {
+	if s == nil {
+		return
+	}
+
+	s.mu.Lock()
+	if len(s.dirty) == 0 {
+		s.mu.Unlock()
+		return
+	}
+	pending := s.dirty
+	s.dirty = make(map[string]time.Time)
+	s.mu.Unlock()
+
+	written := 0
+	err := s.db.Update(func(tx *bolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists([]byte(stateBucket))
+		if err != nil {
+			return err
+		}
+		for storageKey, at := range pending {
+			raw := bucket.Get([]byte(storageKey))
+			if raw == nil {
+				continue
+			}
+			var record targetState
+			if err := json.Unmarshal(raw, &record); err != nil {
+				continue
+			}
+			record.LastProbeAt = at
+			encoded, err := json.Marshal(record)
+			if err != nil {
+				continue
+			}
+			if err := bucket.Put([]byte(storageKey), encoded); err != nil {
+				return err
+			}
+			written++
+		}
+		return nil
+	})
+	if err != nil {
+		// The timestamps are a scheduling optimization, not correctness state —
+		// drop them rather than retrying and growing the pending set unbounded.
+		s.logger.Warn("failed to flush probe state timestamps",
+			slog.Int("pending", len(pending)),
+			slog.String("error", err.Error()))
+		return
+	}
+
+	s.logger.Debug("flushed probe state timestamps", slog.Int("records", written))
+}
+
+// flushLoop coalesces pending timestamp writes until the store is closed.
+func (s *stateStore) flushLoop() {
+	defer close(s.done)
+
+	ticker := time.NewTicker(s.flushInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			s.Flush()
+		case <-s.stop:
+			return
+		}
+	}
+}
+
+// Close stops the flush loop, writes any pending timestamps, and closes the
+// database. It is safe to call on a nil store.
+func (s *stateStore) Close() {
+	if s == nil {
+		return
+	}
+	close(s.stop)
+	<-s.done
+	s.Flush()
+	if err := s.db.Close(); err != nil {
+		s.logger.Warn("failed to close persistent probe state",
+			slog.String("error", err.Error()))
+	}
+}

--- a/internal/probe/state_dump.go
+++ b/internal/probe/state_dump.go
@@ -1,0 +1,82 @@
+package probe
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+// dumpRecord is one entry in the -dump-state output. Records that would be
+// ignored at load time are included too, flagged with the reason, so a dump can
+// be used to diagnose a store the prober is silently skipping over.
+type dumpRecord struct {
+	Key   string       `json:"key"`
+	Valid bool         `json:"valid"`
+	Error string       `json:"error,omitempty"`
+	State *targetState `json:"state,omitempty"`
+	Raw   string       `json:"raw,omitempty"`
+}
+
+// DumpState writes the contents of the state database at path to w as JSON.
+// The database is opened read-only, so a running prober is unaffected.
+func DumpState(path string, w io.Writer) error {
+	if path == "" {
+		return errors.New("no state database path configured")
+	}
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("state database %s: %w", path, err)
+	}
+
+	db, err := bolt.Open(path, 0o600, &bolt.Options{ReadOnly: true, Timeout: stateOpenTimeout})
+	if err != nil {
+		return fmt.Errorf("opening state database %s: %w", path, err)
+	}
+	defer db.Close()
+
+	now := time.Now()
+	records := make([]dumpRecord, 0)
+
+	err = db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(stateBucket))
+		if bucket == nil {
+			return nil
+		}
+		return bucket.ForEach(func(k, v []byte) error {
+			entry := dumpRecord{Key: strings.ReplaceAll(string(k), "\x00", "|")}
+
+			var record targetState
+			if err := json.Unmarshal(v, &record); err != nil {
+				entry.Error = err.Error()
+				entry.Raw = string(v)
+				records = append(records, entry)
+				return nil
+			}
+			entry.State = &record
+
+			switch {
+			case record.validate(now) != nil:
+				entry.Error = record.validate(now).Error()
+			case string(record.key().storageKey()) != string(k):
+				entry.Error = "record identity does not match its key"
+			default:
+				entry.Valid = true
+			}
+
+			records = append(records, entry)
+			return nil
+		})
+	})
+	if err != nil {
+		return fmt.Errorf("reading state database: %w", err)
+	}
+
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(records)
+}

--- a/internal/probe/state_dump.go
+++ b/internal/probe/state_dump.go
@@ -12,9 +12,9 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
-// dumpRecord is one entry in the -dump-state output. Records that would be
-// ignored at load time are included too, flagged with the reason, so a dump can
-// be used to diagnose a store the prober is silently skipping over.
+// dumpRecord is one entry in a state dump. Records that would be ignored at load
+// time are included too, flagged with the reason, so a dump can be used to
+// diagnose a store the prober is silently skipping over.
 type dumpRecord struct {
 	Key   string       `json:"key"`
 	Valid bool         `json:"valid"`
@@ -23,26 +23,11 @@ type dumpRecord struct {
 	Raw   string       `json:"raw,omitempty"`
 }
 
-// DumpState writes the contents of the state database at path to w as JSON.
-// The database is opened read-only, so a running prober is unaffected.
-func DumpState(path string, w io.Writer) error {
-	if path == "" {
-		return errors.New("no state database path configured")
-	}
-	if _, err := os.Stat(path); err != nil {
-		return fmt.Errorf("state database %s: %w", path, err)
-	}
-
-	db, err := bolt.Open(path, 0o600, &bolt.Options{ReadOnly: true, Timeout: stateOpenTimeout})
-	if err != nil {
-		return fmt.Errorf("opening state database %s: %w", path, err)
-	}
-	defer db.Close()
-
-	now := time.Now()
+// collectDumpRecords renders every record in the store's bucket, valid or not.
+func collectDumpRecords(db *bolt.DB, now time.Time) ([]dumpRecord, error) {
 	records := make([]dumpRecord, 0)
 
-	err = db.View(func(tx *bolt.Tx) error {
+	err := db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(stateBucket))
 		if bucket == nil {
 			return nil
@@ -59,9 +44,9 @@ func DumpState(path string, w io.Writer) error {
 			}
 			entry.State = &record
 
-			switch {
-			case record.validate(now) != nil:
-				entry.Error = record.validate(now).Error()
+			switch validationErr := record.validate(now); {
+			case validationErr != nil:
+				entry.Error = validationErr.Error()
 			case string(record.key().storageKey()) != string(k):
 				entry.Error = "record identity does not match its key"
 			default:
@@ -73,9 +58,66 @@ func DumpState(path string, w io.Writer) error {
 		})
 	})
 	if err != nil {
-		return fmt.Errorf("reading state database: %w", err)
+		return nil, fmt.Errorf("reading state database: %w", err)
 	}
 
+	return records, nil
+}
+
+// Snapshot renders the current contents of the store. It reads through the
+// already-open database, so it works while the prober is running — unlike
+// DumpState, which has to take the file lock for itself.
+func (s *stateStore) Snapshot() ([]dumpRecord, error) {
+	if s == nil {
+		return nil, errors.New("persistent probe state is not enabled")
+	}
+	return collectDumpRecords(s.db, time.Now())
+}
+
+// StateSnapshot renders the probe state held by this service, for the debug
+// endpoint. Returns an error when persistence is disabled or unavailable.
+func (s *ProbeService) StateSnapshot() ([]dumpRecord, error) {
+	if s == nil {
+		return nil, errors.New("probe service is not running")
+	}
+	return s.state.Snapshot()
+}
+
+// DumpState writes the contents of the state database at path to w as JSON.
+//
+// bbolt guards the file with an exclusive lock held for the lifetime of the
+// process that opened it read-write, and a read-only open still needs a shared
+// lock, so this cannot read the database of a running prober — use the debug
+// endpoint for that. It is for inspecting a stopped prober's volume, or a copy
+// of one.
+func DumpState(path string, w io.Writer) error {
+	if path == "" {
+		return errors.New("no state database path configured")
+	}
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("state database %s: %w", path, err)
+	}
+
+	db, err := bolt.Open(path, 0o600, &bolt.Options{ReadOnly: true, Timeout: stateOpenTimeout})
+	if err != nil {
+		if errors.Is(err, bolt.ErrTimeout) {
+			return fmt.Errorf("state database %s is locked, most likely by a running prober: "+
+				"read it from the live process at %s instead, or stop the prober first", path, stateDebugPath)
+		}
+		return fmt.Errorf("opening state database %s: %w", path, err)
+	}
+	defer db.Close()
+
+	records, err := collectDumpRecords(db, time.Now())
+	if err != nil {
+		return err
+	}
+
+	return WriteDump(w, records)
+}
+
+// WriteDump encodes dump records as indented JSON.
+func WriteDump(w io.Writer, records []dumpRecord) error {
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(records)

--- a/internal/probe/state_test.go
+++ b/internal/probe/state_test.go
@@ -1,0 +1,373 @@
+package probe
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/eternisai/enchanted-proxy/internal/logger"
+)
+
+// testLogger returns a logger that suppresses everything the store emits, so
+// test output stays readable.
+func testLogger() *logger.Logger {
+	return logger.New(logger.Config{Level: slog.LevelError + 1, Format: "json"})
+}
+
+func testKey() targetKey {
+	return newTargetKey("OpenAI", "openai/gpt-5.5", "https://api.openai.com/v1", "gpt-5.5")
+}
+
+// openTestStore opens a store in a temp dir with a flush interval long enough
+// that the background loop never fires during the test.
+func openTestStore(t *testing.T, path string) *stateStore {
+	t.Helper()
+	store := openStateStore(path, time.Hour, testLogger())
+	if store == nil {
+		t.Fatal("openStateStore returned nil for a usable path")
+	}
+	t.Cleanup(store.Close)
+	return store
+}
+
+func TestTargetKeyNormalizesBaseURL(t *testing.T) {
+	withSlash := newTargetKey("OpenAI", "openai/gpt-5.5", "https://api.openai.com/v1/", "gpt-5.5")
+	withoutSlash := newTargetKey("OpenAI", "openai/gpt-5.5", "https://api.openai.com/v1", "gpt-5.5")
+
+	if withSlash != withoutSlash {
+		t.Errorf("trailing slash changed the key: %+v vs %+v", withSlash, withoutSlash)
+	}
+	if string(withSlash.storageKey()) != string(withoutSlash.storageKey()) {
+		t.Error("trailing slash changed the storage key")
+	}
+}
+
+func TestTargetKeyStorageKeyIsInjective(t *testing.T) {
+	// Components that would collide under a naive delimiter-free concatenation.
+	a := newTargetKey("a", "bc", "https://x", "y")
+	b := newTargetKey("ab", "c", "https://x", "y")
+
+	if string(a.storageKey()) == string(b.storageKey()) {
+		t.Errorf("distinct targets produced the same storage key: %q", a.storageKey())
+	}
+}
+
+func TestStateStoreRoundTripAcrossRestart(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	key := testKey()
+	changedAt := time.Now().Add(-30 * time.Minute).Truncate(time.Second)
+
+	store := openStateStore(path, time.Hour, testLogger())
+	if store == nil {
+		t.Fatal("openStateStore returned nil")
+	}
+	store.RecordStateChange(key, stateFailing, changedAt)
+	store.Close()
+
+	// Reopen, as a restarted pod would.
+	reopened := openTestStore(t, path)
+	loaded := reopened.Load()
+
+	record, ok := loaded[key]
+	if !ok {
+		t.Fatalf("state for %+v was not restored; got %d records", key, len(loaded))
+	}
+	if record.State != stateFailing {
+		t.Errorf("state = %q, want %q", record.State, stateFailing)
+	}
+	if !record.StateChangedAt.Equal(changedAt) {
+		t.Errorf("state_changed_at = %s, want %s", record.StateChangedAt, changedAt)
+	}
+	if !record.LastProbeAt.Equal(changedAt) {
+		t.Errorf("last_probe_at = %s, want %s (state changes stamp both)", record.LastProbeAt, changedAt)
+	}
+}
+
+func TestStateStoreMissingDatabaseIsNotAnError(t *testing.T) {
+	// A fresh volume: the directory exists but holds no database yet.
+	path := filepath.Join(t.TempDir(), "state.db")
+
+	store := openTestStore(t, path)
+	if got := store.Load(); len(got) != 0 {
+		t.Errorf("expected no records from a fresh database, got %d", len(got))
+	}
+}
+
+func TestStateStoreCreatesMissingDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "dir", "state.db")
+
+	store := openTestStore(t, path)
+	store.RecordStateChange(testKey(), stateHealthy, time.Now())
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("database was not created at %s: %v", path, err)
+	}
+}
+
+func TestStateStoreDisabledWhenPathEmpty(t *testing.T) {
+	if store := openStateStore("", time.Hour, testLogger()); store != nil {
+		t.Fatal("expected a nil store when no path is configured")
+	}
+}
+
+func TestStateStoreUnusablePathDegradesToNil(t *testing.T) {
+	// A file where a directory needs to be: MkdirAll fails, and the prober must
+	// carry on without persistence rather than refusing to start.
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if store := openStateStore(filepath.Join(blocker, "state.db"), time.Hour, testLogger()); store != nil {
+		store.Close()
+		t.Fatal("expected a nil store for an unusable path")
+	}
+}
+
+func TestNilStoreIsANoOp(t *testing.T) {
+	var store *stateStore
+
+	// Every call site treats persistence as optional; none of these may panic.
+	if got := store.Load(); got != nil {
+		t.Errorf("nil store Load() = %v, want nil", got)
+	}
+	store.RecordStateChange(testKey(), stateHealthy, time.Now())
+	store.RecordProbe(testKey(), time.Now())
+	store.Flush()
+	store.Close()
+}
+
+func TestStateStoreIgnoresInvalidRecords(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	valid := testKey()
+
+	store := openTestStore(t, path)
+	store.RecordStateChange(valid, stateHealthy, time.Now().Add(-time.Hour))
+
+	mismatched := targetState{
+		Version:        stateSchemaVersion,
+		Provider:       "Tinfoil",
+		CanonicalModel: "meta-llama/Llama-3.3-70B",
+		BaseURL:        "https://inference.tinfoil.sh/v1",
+		EffectiveModel: "llama3-3-70b",
+		State:          stateHealthy,
+		StateChangedAt: time.Now().Add(-time.Hour),
+	}
+
+	corrupt := map[string]any{
+		"not JSON at all": "definitely-not-json",
+		"unknown schema version": targetState{
+			Version: 99, Provider: "P", CanonicalModel: "m", BaseURL: "u", EffectiveModel: "e",
+			State: stateHealthy, StateChangedAt: time.Now().Add(-time.Hour),
+		},
+		"unknown state": targetState{
+			Version: stateSchemaVersion, Provider: "P", CanonicalModel: "m", BaseURL: "u", EffectiveModel: "e",
+			State: "somewhere-in-between", StateChangedAt: time.Now().Add(-time.Hour),
+		},
+		"missing identity": targetState{
+			Version: stateSchemaVersion, State: stateHealthy, StateChangedAt: time.Now().Add(-time.Hour),
+		},
+		"zero timestamp": targetState{
+			Version: stateSchemaVersion, Provider: "P", CanonicalModel: "m", BaseURL: "u", EffectiveModel: "e",
+			State: stateHealthy,
+		},
+		"timestamp from the future": targetState{
+			Version: stateSchemaVersion, Provider: "P", CanonicalModel: "m", BaseURL: "u", EffectiveModel: "e",
+			State: stateHealthy, StateChangedAt: time.Now().Add(24 * time.Hour),
+		},
+	}
+
+	// Write the bad rows behind the store's back, as a corrupted volume would.
+	err := store.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(stateBucket))
+		for name, value := range corrupt {
+			var encoded []byte
+			if raw, ok := value.(string); ok {
+				encoded = []byte(raw)
+			} else {
+				encoded, _ = json.Marshal(value)
+			}
+			if err := bucket.Put([]byte("corrupt\x00"+name), encoded); err != nil {
+				return err
+			}
+		}
+		// A record whose identity disagrees with the key it is stored under.
+		encoded, _ := json.Marshal(mismatched)
+		return bucket.Put([]byte("some\x00other\x00key\x00entirely"), encoded)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loaded := store.Load()
+
+	if len(loaded) != 1 {
+		t.Fatalf("loaded %d records, want only the 1 valid one: %+v", len(loaded), loaded)
+	}
+	if _, ok := loaded[valid]; !ok {
+		t.Errorf("the valid record was not loaded; got %+v", loaded)
+	}
+
+	// Ignored, not deleted — no garbage collection.
+	var stored int
+	_ = store.db.View(func(tx *bolt.Tx) error {
+		stored = tx.Bucket([]byte(stateBucket)).Stats().KeyN
+		return nil
+	})
+	if want := len(corrupt) + 2; stored != want {
+		t.Errorf("store holds %d keys, want %d (invalid rows must be ignored, not removed)", stored, want)
+	}
+}
+
+func TestStateStoreCoalescesProbeTimestamps(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	key := testKey()
+	changedAt := time.Now().Add(-time.Hour).Truncate(time.Second)
+
+	store := openTestStore(t, path)
+	store.RecordStateChange(key, stateHealthy, changedAt)
+
+	// Repeated probes must not each hit the disk.
+	first := time.Now().Add(-30 * time.Minute).Truncate(time.Second)
+	last := time.Now().Add(-1 * time.Minute).Truncate(time.Second)
+	store.RecordProbe(key, first)
+	store.RecordProbe(key, last)
+
+	if got := store.Load()[key].LastProbeAt; !got.Equal(changedAt) {
+		t.Errorf("last_probe_at = %s before flush, want the unflushed %s", got, changedAt)
+	}
+
+	store.Flush()
+
+	if got := store.Load()[key].LastProbeAt; !got.Equal(last) {
+		t.Errorf("last_probe_at = %s after flush, want %s", got, last)
+	}
+	// The flush must not disturb the state it is attached to.
+	if got := store.Load()[key]; got.State != stateHealthy || !got.StateChangedAt.Equal(changedAt) {
+		t.Errorf("flush altered the state record: %+v", got)
+	}
+}
+
+func TestStateChangeSupersedesPendingTimestamp(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	key := testKey()
+
+	store := openTestStore(t, path)
+	store.RecordStateChange(key, stateHealthy, time.Now().Add(-time.Hour))
+
+	// A probe that turns out to be a state change: the pending timestamp must not
+	// survive to overwrite the newer one written by the transition.
+	stale := time.Now().Add(-time.Hour).Truncate(time.Second)
+	store.RecordProbe(key, stale)
+
+	changedAt := time.Now().Truncate(time.Second)
+	store.RecordStateChange(key, stateFailing, changedAt)
+	store.Flush()
+
+	record := store.Load()[key]
+	if !record.LastProbeAt.Equal(changedAt) {
+		t.Errorf("last_probe_at = %s, want %s (stale pending timestamp leaked through)", record.LastProbeAt, changedAt)
+	}
+	if record.State != stateFailing {
+		t.Errorf("state = %q, want %q", record.State, stateFailing)
+	}
+}
+
+func TestFlushIgnoresTimestampsForUnknownTargets(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+
+	store := openTestStore(t, path)
+	// A worker that has probed but not yet established a state has nothing for a
+	// bare timestamp to attach to.
+	store.RecordProbe(testKey(), time.Now())
+	store.Flush()
+
+	if got := store.Load(); len(got) != 0 {
+		t.Errorf("flush created %d records from timestamps alone, want 0: %+v", len(got), got)
+	}
+}
+
+func TestCloseFlushesPendingTimestamps(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	key := testKey()
+	probedAt := time.Now().Truncate(time.Second)
+
+	store := openStateStore(path, time.Hour, testLogger())
+	if store == nil {
+		t.Fatal("openStateStore returned nil")
+	}
+	store.RecordStateChange(key, stateHealthy, time.Now().Add(-time.Hour))
+	store.RecordProbe(key, probedAt)
+	store.Close() // graceful shutdown
+
+	reopened := openTestStore(t, path)
+	if got := reopened.Load()[key].LastProbeAt; !got.Equal(probedAt) {
+		t.Errorf("last_probe_at = %s after graceful shutdown, want %s", got, probedAt)
+	}
+}
+
+func TestDumpState(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	key := testKey()
+
+	store := openStateStore(path, time.Hour, testLogger())
+	if store == nil {
+		t.Fatal("openStateStore returned nil")
+	}
+	store.RecordStateChange(key, stateFailing, time.Now().Add(-time.Hour))
+	err := store.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket([]byte(stateBucket)).Put([]byte("junk"), []byte("{not json"))
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.Close()
+
+	var out bytes.Buffer
+	if err := DumpState(path, &out); err != nil {
+		t.Fatalf("DumpState: %v", err)
+	}
+
+	var records []dumpRecord
+	if err := json.Unmarshal(out.Bytes(), &records); err != nil {
+		t.Fatalf("dump output is not valid JSON: %v\n%s", err, out.String())
+	}
+	if len(records) != 2 {
+		t.Fatalf("dumped %d records, want 2: %s", len(records), out.String())
+	}
+
+	var valid, invalid int
+	for _, record := range records {
+		if record.Valid {
+			valid++
+			if record.State == nil || record.State.State != stateFailing {
+				t.Errorf("valid record has unexpected state: %+v", record.State)
+			}
+		} else {
+			invalid++
+			if record.Error == "" {
+				t.Error("invalid record was dumped without a reason")
+			}
+		}
+	}
+	if valid != 1 || invalid != 1 {
+		t.Errorf("dump had %d valid / %d invalid records, want 1 / 1", valid, invalid)
+	}
+}
+
+func TestDumpStateMissingDatabase(t *testing.T) {
+	var out bytes.Buffer
+
+	if err := DumpState(filepath.Join(t.TempDir(), "absent.db"), &out); err == nil {
+		t.Error("expected an error when dumping a database that does not exist")
+	}
+	if err := DumpState("", &out); err == nil {
+		t.Error("expected an error when dumping with no path configured")
+	}
+}

--- a/internal/probe/state_test.go
+++ b/internal/probe/state_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -369,5 +370,48 @@ func TestDumpStateMissingDatabase(t *testing.T) {
 	}
 	if err := DumpState("", &out); err == nil {
 		t.Error("expected an error when dumping with no path configured")
+	}
+}
+
+// TestSnapshotReadsWhileDatabaseIsOpen covers the case DumpState cannot: bbolt
+// holds its file lock for the lifetime of the process that opened the database,
+// so the live view has to be read through the open handle rather than by
+// reopening the file.
+func TestSnapshotReadsWhileDatabaseIsOpen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.db")
+	key := testKey()
+
+	store := openTestStore(t, path)
+	store.RecordStateChange(key, stateFailing, time.Now().Add(-time.Hour))
+
+	// Reopening the same path while the store holds it must fail; shorten the
+	// lock wait so the test does not sit out the production timeout.
+	defer func(orig time.Duration) { stateOpenTimeout = orig }(stateOpenTimeout)
+	stateOpenTimeout = 200 * time.Millisecond
+
+	var discard bytes.Buffer
+	if err := DumpState(path, &discard); err == nil {
+		t.Error("expected DumpState to fail against an open database")
+	} else if !strings.Contains(err.Error(), "locked") {
+		t.Errorf("expected a lock-specific message, got: %v", err)
+	}
+
+	// ...while the in-process snapshot succeeds.
+	records, err := store.Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("snapshot returned %d records, want 1", len(records))
+	}
+	if !records[0].Valid || records[0].State.State != stateFailing {
+		t.Errorf("unexpected snapshot record: %+v", records[0])
+	}
+}
+
+func TestSnapshotOnNilStore(t *testing.T) {
+	var store *stateStore
+	if _, err := store.Snapshot(); err == nil {
+		t.Error("expected an error when persistence is disabled")
 	}
 }

--- a/internal/probe/worker.go
+++ b/internal/probe/worker.go
@@ -88,9 +88,6 @@ func (w *probeWorker) run() {
 	healthy := false
 	consecutiveCount := 0
 
-	ticker := time.NewTicker(w.probe.RetryInterval)
-	defer ticker.Stop()
-
 	// probeNow makes the normal-operation loop probe without waiting for its
 	// first tick, which is how a resumed worker whose interval already elapsed
 	// gets checked right away.
@@ -119,18 +116,28 @@ func (w *probeWorker) run() {
 		}
 		probeNow = true
 	} else {
-		// --- Stage 1: Initial ---
-		// Use retry interval and accumulate consecutive results until one of the
-		// thresholds is crossed. Only send a Slack notification if consecutive
-		// failures reach the failure threshold; initial successes are silent.
-
 		// Run the first probe after the jitter delay.
 		select {
 		case <-time.After(jitter):
 		case <-w.service.shutdown:
 			return
 		}
+	}
 
+	// Created only after the wait above. A ticker started before it would spend
+	// that wait firing into a channel nobody is receiving from, leaving a tick
+	// ready to deliver the instant the first receive happens — which would probe
+	// twice with no interval in between. Starting it here means every tick it
+	// produces corresponds to a real interval boundary, without relying on Reset
+	// to discard what a longer wait left behind.
+	ticker := time.NewTicker(w.probe.RetryInterval)
+	defer ticker.Stop()
+
+	if w.restored == nil {
+		// --- Stage 1: Initial ---
+		// Use retry interval and accumulate consecutive results until one of the
+		// thresholds is crossed. Only send a Slack notification if consecutive
+		// failures reach the failure threshold; initial successes are silent.
 		lastSuccess := false // tracks the previous result to detect outcome flips
 		initial := true
 		for initial {

--- a/internal/probe/worker.go
+++ b/internal/probe/worker.go
@@ -32,6 +32,9 @@ type probeWorker struct {
 	client   *http.Client
 	logger   *logger.Logger
 	slack    *slackNotifier
+
+	key      targetKey    // identity used to persist and restore this worker's state
+	restored *targetState // state recovered from disk at startup; nil if none
 }
 
 // probeResult holds the outcome of a single probe execution.
@@ -79,66 +82,98 @@ func (w *probeWorker) run() {
 		slog.Duration("retry_interval", w.probe.RetryInterval),
 		slog.Int("success_threshold", w.probe.SuccessThreshold),
 		slog.Int("failure_threshold", w.probe.FailureThreshold),
-		slog.Duration("initial_jitter", jitter))
+		slog.Duration("initial_jitter", jitter),
+		slog.Bool("resumed", w.restored != nil))
 
-	// --- Stage 1: Initial ---
-	// Use retry interval and accumulate consecutive results until one of the
-	// thresholds is crossed. Only send a Slack notification if consecutive
-	// failures reach the failure threshold; initial successes are silent.
 	healthy := false
 	consecutiveCount := 0
 
 	ticker := time.NewTicker(w.probe.RetryInterval)
 	defer ticker.Stop()
 
-	// Run the first probe after the jitter delay.
-	select {
-	case <-time.After(jitter):
-	case <-w.service.shutdown:
-		return
-	}
+	// probeNow makes the normal-operation loop probe without waiting for its
+	// first tick, which is how a resumed worker whose interval already elapsed
+	// gets checked right away.
+	probeNow := false
 
-	lastSuccess := false // tracks the previous result to detect outcome flips
-	initial := true
-	for initial {
-		result := w.runProbe()
-		if w.ctx.Err() != nil {
-			break
+	if w.restored != nil {
+		// --- Resumed from persisted state ---
+		// The initial stage exists to discover a state we do not know. Here we do
+		// know it, and running the initial stage anyway would be actively harmful:
+		// its first success is silent by design, so an endpoint that was failing
+		// before the restart would recover without ever announcing it.
+		healthy = w.resume(*w.restored)
+
+		delay := w.resumeDelay(*w.restored, jitter)
+		w.logger.Info("resuming probe from persisted state",
+			slog.String("provider", w.provider),
+			slog.String("model", w.model),
+			slog.String("state", string(w.restored.State)),
+			slog.Time("state_changed_at", w.restored.StateChangedAt),
+			slog.Duration("first_probe_in", delay))
+
+		select {
+		case <-time.After(delay):
+		case <-w.service.shutdown:
+			return
+		}
+		probeNow = true
+	} else {
+		// --- Stage 1: Initial ---
+		// Use retry interval and accumulate consecutive results until one of the
+		// thresholds is crossed. Only send a Slack notification if consecutive
+		// failures reach the failure threshold; initial successes are silent.
+
+		// Run the first probe after the jitter delay.
+		select {
+		case <-time.After(jitter):
+		case <-w.service.shutdown:
+			return
 		}
 
-		// Reset counter on outcome flip.
-		if result.success != lastSuccess {
-			consecutiveCount = 0
-			lastSuccess = result.success
-		}
-		consecutiveCount++
-
-		if result.success {
-			if consecutiveCount >= w.probe.SuccessThreshold {
-				healthy = true
-				consecutiveCount = 0
-				w.logStateChange(result)
-				initial = false
-			} else {
-				w.logProbeResult(result, consecutiveCount, w.probe.SuccessThreshold)
+		lastSuccess := false // tracks the previous result to detect outcome flips
+		initial := true
+		for initial {
+			result := w.runProbe()
+			if w.ctx.Err() != nil {
+				break
 			}
-		} else {
-			if consecutiveCount >= w.probe.FailureThreshold {
-				healthy = false
-				consecutiveCount = 0
-				w.logStateChange(result)
-				w.sendSlackNotification(result)
-				initial = false
-			} else {
-				w.logProbeResult(result, consecutiveCount, w.probe.FailureThreshold)
-			}
-		}
+			w.service.state.RecordProbe(w.key, time.Now())
 
-		if initial {
-			select {
-			case <-ticker.C:
-			case <-w.service.shutdown:
-				return
+			// Reset counter on outcome flip.
+			if result.success != lastSuccess {
+				consecutiveCount = 0
+				lastSuccess = result.success
+			}
+			consecutiveCount++
+
+			if result.success {
+				if consecutiveCount >= w.probe.SuccessThreshold {
+					healthy = true
+					consecutiveCount = 0
+					w.logStateChange(result)
+					initial = false
+				} else {
+					w.logProbeResult(result, consecutiveCount, w.probe.SuccessThreshold)
+				}
+			} else {
+				if consecutiveCount >= w.probe.FailureThreshold {
+					healthy = false
+					consecutiveCount = 0
+					w.logStateChange(result)
+					w.sendSlackNotification(result)
+					initial = false
+				} else {
+					w.logProbeResult(result, consecutiveCount, w.probe.FailureThreshold)
+				}
+			}
+
+			if initial {
+				select {
+				case <-ticker.C:
+				case <-w.service.shutdown:
+					return
+				}
 			}
 		}
 	}
@@ -153,61 +188,112 @@ func (w *probeWorker) run() {
 	}
 
 	for {
-		select {
-		case <-ticker.C:
-			result := w.runProbe()
-			if w.ctx.Err() != nil {
-				continue
+		if !probeNow {
+			select {
+			case <-ticker.C:
+			case <-w.service.shutdown:
+				w.logger.Debug("stopped probe worker",
+					slog.String("provider", w.provider),
+					slog.String("model", w.model))
+				return
 			}
+		}
+		probeNow = false
 
-			if healthy {
-				if result.success {
-					if consecutiveCount > 0 {
-						// Had some failures before — restore normal interval.
-						consecutiveCount = 0
-						ticker.Reset(w.probe.Interval)
-					}
-					w.logProbeResult(result, consecutiveCount, w.probe.FailureThreshold)
-				} else {
-					consecutiveCount++
-					if consecutiveCount == 1 {
-						// First failure — switch to retry interval immediately
-						// so we can quickly determine if this is a real outage.
-						ticker.Reset(w.probe.RetryInterval)
-					}
-					if consecutiveCount >= w.probe.FailureThreshold {
-						healthy = false
-						consecutiveCount = 0
-						w.logStateChange(result)
-						w.sendSlackNotification(result)
-					} else {
-						w.logProbeResult(result, consecutiveCount, w.probe.FailureThreshold)
-					}
-				}
-			} else {
-				if result.success {
-					consecutiveCount++
-					if consecutiveCount >= w.probe.SuccessThreshold {
-						healthy = true
-						consecutiveCount = 0
-						ticker.Reset(w.probe.Interval)
-						w.logStateChange(result)
-						w.sendSlackNotification(result)
-					} else {
-						w.logProbeResult(result, consecutiveCount, w.probe.SuccessThreshold)
-					}
-				} else {
+		result := w.runProbe()
+		if w.ctx.Err() != nil {
+			continue
+		}
+		w.service.state.RecordProbe(w.key, time.Now())
+
+		if healthy {
+			if result.success {
+				if consecutiveCount > 0 {
+					// Had some failures before — restore normal interval.
 					consecutiveCount = 0
+					ticker.Reset(w.probe.Interval)
+				}
+				w.logProbeResult(result, consecutiveCount, w.probe.FailureThreshold)
+			} else {
+				consecutiveCount++
+				if consecutiveCount == 1 {
+					// First failure — switch to retry interval immediately
+					// so we can quickly determine if this is a real outage.
+					ticker.Reset(w.probe.RetryInterval)
+				}
+				if consecutiveCount >= w.probe.FailureThreshold {
+					healthy = false
+					consecutiveCount = 0
+					w.logStateChange(result)
+					w.sendSlackNotification(result)
+				} else {
+					w.logProbeResult(result, consecutiveCount, w.probe.FailureThreshold)
+				}
+			}
+		} else {
+			if result.success {
+				consecutiveCount++
+				if consecutiveCount >= w.probe.SuccessThreshold {
+					healthy = true
+					consecutiveCount = 0
+					ticker.Reset(w.probe.Interval)
+					w.logStateChange(result)
+					w.sendSlackNotification(result)
+				} else {
 					w.logProbeResult(result, consecutiveCount, w.probe.SuccessThreshold)
 				}
+			} else {
+				consecutiveCount = 0
+				w.logProbeResult(result, consecutiveCount, w.probe.SuccessThreshold)
 			}
-		case <-w.service.shutdown:
-			w.logger.Debug("stopped probe worker",
-				slog.String("provider", w.provider),
-				slog.String("model", w.model))
-			return
 		}
 	}
+}
+
+// resume adopts a persisted state as the worker's current state and returns
+// whether that state is healthy.
+//
+// The health gauge is published immediately so the metric reflects what is known
+// from the moment the process starts, instead of reading as absent (and, for
+// alerting rules, as a gap) until the first probe of the new process completes.
+//
+// No notification is sent: the transition into this state was announced by the
+// process that recorded it.
+func (w *probeWorker) resume(state targetState) bool {
+	healthy := state.State == stateHealthy
+	if healthy {
+		probeHealthy.WithLabelValues(w.provider, w.model).Set(1)
+	} else {
+		probeHealthy.WithLabelValues(w.provider, w.model).Set(0)
+	}
+	return healthy
+}
+
+// resumeDelay returns how long a resumed worker should wait before its first
+// probe: the unelapsed remainder of the interval that applies to its restored
+// state, plus the usual jitter.
+//
+// Measuring from the last probe rather than from the state change is what keeps a
+// crash-looping pod from re-probing every endpoint on every restart; the state
+// change timestamp is the fallback for records written before a timestamp was
+// ever flushed. Either way, an interval that has already elapsed yields a delay of
+// just the jitter, so a long-down deployment is re-checked promptly.
+func (w *probeWorker) resumeDelay(state targetState, jitter time.Duration) time.Duration {
+	interval := w.probe.Interval
+	if state.State != stateHealthy {
+		interval = w.probe.RetryInterval
+	}
+
+	since := state.LastProbeAt
+	if since.IsZero() {
+		since = state.StateChangedAt
+	}
+
+	// Clamped to [0, interval]: a clock that moved backwards between processes
+	// must not push the first probe further out than a full interval.
+	remaining := min(max(interval-time.Since(since), 0), interval)
+
+	return remaining + jitter
 }
 
 // logProbeResult logs an individual probe result that did not cause a state transition
@@ -254,14 +340,17 @@ func (w *probeWorker) logProbeResult(result probeResult, consecutiveCount, thres
 	}
 }
 
-// logStateChange logs a probe state transition (initial state, recovery, or new failure)
-// and updates the health gauge metric.
+// logStateChange logs a probe state transition (initial state, recovery, or new
+// failure), updates the health gauge metric, and persists the new state so a
+// restart resumes from it rather than rediscovering it.
 func (w *probeWorker) logStateChange(result probeResult) {
 	if result.success {
 		probeHealthy.WithLabelValues(w.provider, w.model).Set(1)
 	} else {
 		probeHealthy.WithLabelValues(w.provider, w.model).Set(0)
 	}
+
+	w.service.state.RecordStateChange(w.key, healthStateFor(result.success), time.Now())
 
 	if result.success {
 		attrs := []any{

--- a/internal/probe/worker_resume_test.go
+++ b/internal/probe/worker_resume_test.go
@@ -1,0 +1,308 @@
+package probe
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eternisai/enchanted-proxy/internal/config"
+	"github.com/eternisai/enchanted-proxy/internal/routing"
+)
+
+// slackRecorder stands in for the Slack webhook and records what the worker sends.
+type slackRecorder struct {
+	server *httptest.Server
+
+	mu       sync.Mutex
+	messages []slackMessage
+}
+
+func newSlackRecorder(t *testing.T) *slackRecorder {
+	t.Helper()
+	r := &slackRecorder{}
+	r.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var msg slackMessage
+		_ = json.NewDecoder(req.Body).Decode(&msg)
+		r.mu.Lock()
+		r.messages = append(r.messages, msg)
+		r.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(r.server.Close)
+	return r
+}
+
+func (r *slackRecorder) received() []slackMessage {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]slackMessage(nil), r.messages...)
+}
+
+// awaitMessages waits for at least n notifications, returning what arrived.
+func (r *slackRecorder) awaitMessages(n int, timeout time.Duration) []slackMessage {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if got := r.received(); len(got) >= n {
+			return got
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return r.received()
+}
+
+// newProbeEndpoint starts a fake model endpoint. Each call to respond decides the
+// status and content of the next probe response.
+func newProbeEndpoint(t *testing.T, status int, content string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]string{"content": content}},
+			},
+			"usage": map[string]int{"prompt_tokens": 3, "completion_tokens": 1},
+		})
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// newTestWorker assembles a worker against a fake endpoint and Slack webhook, with
+// intervals short enough to keep tests fast and thresholds of 1 so a single result
+// drives a transition.
+func newTestWorker(t *testing.T, model string, endpoint *httptest.Server, slack *slackRecorder, restored *targetState) *probeWorker {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	service := &ProbeService{
+		logger:   testLogger(),
+		slack:    newSlackNotifier(slack.server.URL),
+		shutdown: make(chan struct{}),
+		cancel:   cancel,
+	}
+	t.Cleanup(service.Shutdown)
+
+	expected := "OK"
+	provider := &routing.ProviderConfig{
+		BaseURL: endpoint.URL,
+		APIKey:  "test-key",
+		Name:    "TestProvider",
+		Model:   model,
+		APIType: config.APITypeChatCompletions,
+	}
+
+	return &probeWorker{
+		service:  service,
+		ctx:      ctx,
+		provider: "TestProvider",
+		model:    model,
+		endpoint: provider,
+		probe: &routing.ProbeConfig{
+			Enabled:          true,
+			Interval:         50 * time.Millisecond,
+			RetryInterval:    20 * time.Millisecond,
+			Prompt:           "Say OK",
+			ExpectedResponse: &expected,
+			MaxTokens:        16,
+			SuccessThreshold: 1,
+			FailureThreshold: 1,
+		},
+		client:   endpoint.Client(),
+		logger:   service.logger,
+		slack:    service.slack,
+		key:      newTargetKey("TestProvider", model, endpoint.URL, model),
+		restored: restored,
+	}
+}
+
+func start(t *testing.T, w *probeWorker) {
+	t.Helper()
+	w.service.wg.Add(1)
+	go w.run()
+}
+
+// failingState returns a persisted record for a target that was failing when the
+// previous process recorded it — the situation an operator restart is meant to fix.
+func failingState(w *probeWorker, age time.Duration) *targetState {
+	at := time.Now().Add(-age)
+	return &targetState{
+		Version:        stateSchemaVersion,
+		Provider:       w.key.Provider,
+		CanonicalModel: w.key.CanonicalModel,
+		BaseURL:        w.key.BaseURL,
+		EffectiveModel: w.key.EffectiveModel,
+		State:          stateFailing,
+		StateChangedAt: at,
+		LastProbeAt:    at,
+	}
+}
+
+// TestResumedFailingWorkerAnnouncesRecovery covers the bug this state exists for:
+// an endpoint that was failing before a restart — typically restarted to install a
+// replacement API key — must announce its recovery, not absorb it as an initial
+// state.
+func TestResumedFailingWorkerAnnouncesRecovery(t *testing.T) {
+	endpoint := newProbeEndpoint(t, http.StatusOK, "OK")
+	slack := newSlackRecorder(t)
+
+	w := newTestWorker(t, "resumed-recovery", endpoint, slack, nil)
+	w.restored = failingState(w, time.Hour)
+
+	start(t, w)
+
+	messages := slack.awaitMessages(1, 3*time.Second)
+	if len(messages) == 0 {
+		t.Fatal("no recovery notification was sent for an endpoint that was failing before the restart")
+	}
+	if messages[0].Text != "Probe succeeded: TestProvider / resumed-recovery" {
+		t.Errorf("unexpected notification text: %q", messages[0].Text)
+	}
+}
+
+// TestFreshWorkerIsSilentOnInitialSuccess pins the existing behaviour that the
+// resume path deliberately bypasses: with no prior state there is nothing to
+// recover from, so establishing an initial healthy state stays quiet.
+func TestFreshWorkerIsSilentOnInitialSuccess(t *testing.T) {
+	endpoint := newProbeEndpoint(t, http.StatusOK, "OK")
+	slack := newSlackRecorder(t)
+
+	w := newTestWorker(t, "fresh-healthy", endpoint, slack, nil)
+	start(t, w)
+
+	if got := slack.awaitMessages(1, 300*time.Millisecond); len(got) != 0 {
+		t.Errorf("establishing an initial healthy state sent %d notification(s), want 0", len(got))
+	}
+}
+
+// TestResumedFailingWorkerDoesNotRepeatItsFailure ensures resuming is silent about
+// the state it inherited: that transition was already announced by the process
+// that recorded it, and re-announcing it on every restart would be noise.
+func TestResumedFailingWorkerDoesNotRepeatItsFailure(t *testing.T) {
+	endpoint := newProbeEndpoint(t, http.StatusInternalServerError, "")
+	slack := newSlackRecorder(t)
+
+	w := newTestWorker(t, "resumed-still-failing", endpoint, slack, nil)
+	w.restored = failingState(w, time.Hour)
+
+	start(t, w)
+
+	if got := slack.awaitMessages(1, 300*time.Millisecond); len(got) != 0 {
+		t.Errorf("a still-failing resumed endpoint sent %d notification(s), want 0", len(got))
+	}
+}
+
+// TestResumedHealthyWorkerStillAlerts confirms resuming does not disarm alerting:
+// a target restored as healthy must still report a failure it runs into.
+func TestResumedHealthyWorkerStillAlerts(t *testing.T) {
+	endpoint := newProbeEndpoint(t, http.StatusInternalServerError, "")
+	slack := newSlackRecorder(t)
+
+	w := newTestWorker(t, "resumed-healthy", endpoint, slack, nil)
+	state := failingState(w, time.Hour)
+	state.State = stateHealthy
+	w.restored = state
+
+	start(t, w)
+
+	messages := slack.awaitMessages(1, 3*time.Second)
+	if len(messages) == 0 {
+		t.Fatal("no failure notification was sent for an endpoint restored as healthy")
+	}
+	if messages[0].Text != "Probe failed: TestProvider / resumed-healthy" {
+		t.Errorf("unexpected notification text: %q", messages[0].Text)
+	}
+}
+
+func TestResumeDelay(t *testing.T) {
+	const (
+		interval      = 15 * time.Minute
+		retryInterval = time.Minute
+		jitter        = 10 * time.Second
+	)
+
+	w := &probeWorker{probe: &routing.ProbeConfig{Interval: interval, RetryInterval: retryInterval}}
+
+	tests := []struct {
+		name        string
+		state       healthState
+		lastProbe   time.Duration // age of LastProbeAt; 0 means unset
+		stateChange time.Duration // age of StateChangedAt
+		want        time.Duration // expected delay excluding jitter
+	}{
+		{
+			name:        "healthy mid-interval waits out the remainder",
+			state:       stateHealthy,
+			lastProbe:   5 * time.Minute,
+			stateChange: time.Hour,
+			want:        10 * time.Minute,
+		},
+		{
+			name:        "healthy with an elapsed interval probes at once",
+			state:       stateHealthy,
+			lastProbe:   30 * time.Minute,
+			stateChange: time.Hour,
+			want:        0,
+		},
+		{
+			name:        "failing uses the retry interval, not the probe interval",
+			state:       stateFailing,
+			lastProbe:   30 * time.Second,
+			stateChange: time.Hour,
+			want:        30 * time.Second,
+		},
+		{
+			name:        "failing with an elapsed retry interval probes at once",
+			state:       stateFailing,
+			lastProbe:   5 * time.Minute,
+			stateChange: time.Hour,
+			want:        0,
+		},
+		{
+			name:        "falls back to the state change when no probe was flushed",
+			state:       stateHealthy,
+			lastProbe:   0,
+			stateChange: 5 * time.Minute,
+			want:        10 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := targetState{
+				State:          tt.state,
+				StateChangedAt: time.Now().Add(-tt.stateChange),
+			}
+			if tt.lastProbe > 0 {
+				state.LastProbeAt = time.Now().Add(-tt.lastProbe)
+			}
+
+			got := w.resumeDelay(state, jitter)
+
+			// Tolerance absorbs the wall clock advancing during the call.
+			if diff := got - (tt.want + jitter); diff < -time.Second || diff > time.Second {
+				t.Errorf("resumeDelay = %s, want ~%s", got, tt.want+jitter)
+			}
+		})
+	}
+}
+
+// TestResumeDelayClampsFutureTimestamps guards against a clock that moved
+// backwards between processes pushing the first probe beyond a full interval.
+func TestResumeDelayClampsFutureTimestamps(t *testing.T) {
+	w := &probeWorker{probe: &routing.ProbeConfig{Interval: 15 * time.Minute, RetryInterval: time.Minute}}
+
+	state := targetState{
+		State:          stateHealthy,
+		StateChangedAt: time.Now(),
+		LastProbeAt:    time.Now().Add(2 * time.Hour),
+	}
+
+	if got := w.resumeDelay(state, 0); got > 15*time.Minute {
+		t.Errorf("resumeDelay = %s, want at most one interval (15m)", got)
+	}
+}

--- a/internal/probe/worker_resume_test.go
+++ b/internal/probe/worker_resume_test.go
@@ -306,3 +306,62 @@ func TestResumeDelayClampsFutureTimestamps(t *testing.T) {
 		t.Errorf("resumeDelay = %s, want at most one interval (15m)", got)
 	}
 }
+
+// TestResumedWorkerDoesNotDoubleProbe guards the interaction between the resume
+// delay and the retry ticker. The ticker channel holds one tick, and Reset does
+// not drain it, so a ticker started before the resume wait can leave a tick
+// buffered — the immediate resume probe then falls straight through the next
+// select and probes again with no interval in between.
+func TestResumedWorkerDoesNotDoubleProbe(t *testing.T) {
+	var mu sync.Mutex
+	var probeTimes []time.Time
+
+	endpoint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		probeTimes = append(probeTimes, time.Now())
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{"message": map[string]string{"content": "OK"}}},
+		})
+	}))
+	t.Cleanup(endpoint.Close)
+
+	slack := newSlackRecorder(t)
+	w := newTestWorker(t, "no-double-probe", endpoint, slack, nil)
+	// A healthy resume waits out the probe interval while the ticker runs at the
+	// much shorter retry interval, so a tick is certain to buffer during the wait.
+	w.probe.Interval = 300 * time.Millisecond
+	w.probe.RetryInterval = 20 * time.Millisecond
+
+	state := failingState(w, 0)
+	state.State = stateHealthy
+	state.LastProbeAt = time.Now() // full interval still to run
+	w.restored = state
+
+	start(t, w)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(probeTimes)
+		mu.Unlock()
+		if n >= 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	mu.Lock()
+	times := append([]time.Time(nil), probeTimes...)
+	mu.Unlock()
+
+	if len(times) < 2 {
+		t.Skipf("only %d probe(s) observed; cannot assess spacing", len(times))
+	}
+	gap := times[1].Sub(times[0])
+	if gap < w.probe.Interval/2 {
+		t.Errorf("second probe came %s after the first, want at least ~%s: a stale ticker tick fired immediately",
+			gap, w.probe.Interval)
+	}
+}


### PR DESCRIPTION
## Problem

The llm-prober is stateless. Every probe worker starts in `worker.go`'s "Stage 1: Initial", where a first success is **silent by design** — announcing "healthy" for every endpoint on every startup would be noise.

That loses the recovery notification in exactly the case where it matters most:

1. An endpoint starts failing (say, an expired API key) → prober alerts to Slack.
2. An operator rotates the key and restarts the workload to pick it up.
3. The next probe succeeds — and the success is swallowed as an "initial state".
4. Nobody is ever told the outage ended.

## Solution

Probe state now persists to disk. A target with a stored state **skips the initial stage** and resumes directly in normal operation, so its next transition is a real transition and gets announced. The state it resumed *into* is not re-announced — the process that recorded it already did that.

### Storage

[bbolt](https://github.com/etcd-io/bbolt): single file, pure Go (the prober builds `CGO_ENABLED=0`, so cgo SQLite was out), transactional. Pinned to `v1.4.3` deliberately — `v1.5.0` requires go 1.25 and would have forced a `go` directive bump plus `x/sys`/`x/sync` upgrades on the module shared with the enclave server. The `go.mod` diff is a single line.

One record per target, updated in place. Probe attempts are **not** journalled.

### Identity

Keyed on the full endpoint tuple — `provider ∥ canonical_model ∥ normalized base_url ∥ effective_model` — mirroring the `(base_url, effective_model)` pair `NewProbeService` already deduplicates workers on, plus the two names that label the target's metrics.

A config change that reroutes a model to a different provider or upstream name therefore starts that target fresh rather than inheriting the state of the endpoint it replaced. That's intended: it's a different endpoint. Old records are never looked up again — there is no garbage collection.

### Write volume

State transitions are written through immediately, in their own transaction — one lost to an ungraceful shutdown would resurrect the bug this exists to fix.

Last-probe timestamps are held in memory and coalesced: one transaction per flush interval (default 5m) plus one on graceful shutdown. Write volume stays **flat** regardless of endpoint count or retry rate:

| Scenario | Written through | Coalesced |
|---|---|---|
| Steady state (15m interval) | ~1,250 txn/day | ~290 txn/day |
| Outage, every target on 1m retry | ~18,700 txn/day | ~290 txn/day |

An ungraceful kill loses at most one flush interval of timestamps, costing at most one early re-probe per target. Notification correctness is unaffected — that rides on state transitions, which are never buffered.

### Startup

Each resumed worker adopts its stored state, publishes its health gauge immediately (so `model_router_probe_healthy` has no gap while the first probe runs), and schedules the first probe at `last_probe_at + interval` — probe interval when healthy, retry interval when failing, plus the usual jitter. Measuring from the last probe rather than the state change is what stops a crash-looping pod from re-probing every provider on every restart.

### Failure handling

Persistence is best-effort throughout. A missing, unwritable, locked, or corrupt database produces a **warning** and the prober runs exactly as before — losing restart continuity is never a reason to stop monitoring. Individual records failing validation (bad JSON, unknown schema version, unknown state, incomplete identity, missing/future timestamps, identity disagreeing with its key) are logged and skipped, never deleted.

### Operator tooling

A running prober is read via `/debug/state`, served in-process on a loopback-only listener (`-debug-listen`, default `127.0.0.1:9091`) so it is unreachable from outside the pod — the metrics port is bound on all interfaces and unauthenticated, and the namespace has no NetworkPolicy — bbolt holds an exclusive file lock, so nothing outside the process can open the database while it runs. `-dump-state` covers the offline case (a stopped prober, or a copy of its volume) and fails fast pointing at the endpoint rather than hanging on the lock. Both views include records that would be skipped at load, flagged with the reason.

```bash
kubectl exec sts/llm-prober -- wget -qO- localhost:9091/debug/state | jq '.[] | select(.valid) | {key, state: .state.state}'
```

## Verification

Beyond unit tests, this was validated end-to-end with the real binary against a fake provider and Slack webhook:

1. Endpoint failing → `Probe failed` sent, `failing` persisted.
2. Restart with a working key → resumed as failing, gauge `0` immediately, first probe deferred by the retry-interval remainder (crash-loop protection observable in the log: `first_probe_in=16.8s`).
3. Probe succeeds → **`Probe succeeded`** sent — the notification previously lost — and `healthy` persisted.

Neutralizing the resume path makes `TestResumedFailingWorkerAnnouncesRecovery` fail, confirming the test covers the actual bug rather than passing vacuously.

All four degraded paths were exercised against the real binary and each warns and keeps monitoring: corrupt DB (`invalid database`), read-only volume (`permission denied`), lock held by an outgoing pod (`timeout`), and persistence disabled.

Full suite passes under `-race`.

## Deployment

The image defaults `LLM_PROBER_STATE_DB=/var/lib/llm-prober/state.db`, but a volume must be mounted there for the state to persist at all — a restarted container in Kubernetes is a *new* container built from the image, so a database on the container's own filesystem is discarded every restart. Without a volume the prober simply starts fresh each time, which is the pre-existing behaviour.

Manifest changes are a companion PR in `gitops-apps`. Requirements are documented in `docs/llm-prober-state.md`: a volume at `/var/lib/llm-prober`, `securityContext.fsGroup` (the container runs as non-root `prober`; a `root:root` mount silently degrades to stateless), and an update strategy that never overlaps two pods — bbolt takes an exclusive file lock, and the incoming pod would wait 10s, give up, and run stateless for its entire lifetime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent probe health state across restarts.
  * Probes resume previous health status while avoiding duplicate alerts.
  * Added configurable state storage, flush intervals, JSON exports, and live state inspection.
  * Added an optional loopback-only debug listener for secure state access.
  * Added deployment support for persistent storage and safe rollouts.
* **Documentation**
  * Documented persistence, configuration, recovery behavior, debugging, and deployment requirements.
* **Bug Fixes**
  * Improved handling of invalid or unavailable state data with graceful fallback to stateless operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

