### PR TITLE
fix(probe): bind both loopback families for the debug endpoint

### DIFF
--- a/cmd/llm-prober/main.go
+++ b/cmd/llm-prober/main.go
@@ -28,7 +28,7 @@ func main() {
 	stateDB := flag.String("state-db", "", "path to the persistent probe state database (default: LLM_PROBER_STATE_DB env; empty disables persistence)")
 	stateFlush := flag.Duration("state-flush-interval", 5*time.Minute, "how often pending probe timestamps are coalesced into a single write")
 	dumpState := flag.Bool("dump-state", false, "print the contents of the probe state database as JSON and exit")
-	debugAddr := flag.String("debug-listen", "127.0.0.1:9091", "loopback address serving /debug/state; must be a loopback host; empty disables it")
+	debugAddr := flag.String("debug-listen", "localhost:9091", "loopback address serving /debug/state; must be a loopback host; empty disables it")
 	flag.Parse()
 
 	// Resolve config file path: flag > env > default.
@@ -149,7 +149,7 @@ func main() {
 		debugListen = ""
 	}
 
-	var debugServer *http.Server
+	var debugServers []*http.Server
 	if debugListen != "" {
 		debugMux := http.NewServeMux()
 		// Reads through the already-open database: bbolt holds its file lock for
@@ -167,20 +167,27 @@ func main() {
 			}
 		})
 
-		debugServer = &http.Server{
-			Addr:              debugListen,
-			Handler:           debugMux,
-			ReadHeaderTimeout: 10 * time.Second,
-			IdleTimeout:       60 * time.Second,
-		}
-
-		go func() {
-			appLog.Info("debug server listening", slog.String("addr", debugListen))
-			if err := debugServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				// Not fatal: losing state introspection must not stop probing.
-				appLog.Warn("debug server error", slog.String("error", err.Error()))
+		for _, addr := range debugAddrs(debugListen) {
+			debugServer := &http.Server{
+				Addr:              addr,
+				Handler:           debugMux,
+				ReadHeaderTimeout: 10 * time.Second,
+				IdleTimeout:       60 * time.Second,
 			}
-		}()
+			debugServers = append(debugServers, debugServer)
+
+			go func() {
+				appLog.Info("debug server listening", slog.String("addr", addr))
+				if err := debugServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+					// Not fatal, and expected on a host without IPv6: as long as one
+					// address binds the endpoint is reachable, and losing state
+					// introspection entirely must still not stop probing.
+					appLog.Warn("debug server error",
+						slog.String("addr", addr),
+						slog.String("error", err.Error()))
+				}
+			}()
+		}
 	}
 
 	// Wait for shutdown signal.
@@ -196,13 +203,39 @@ func main() {
 	if err := server.Shutdown(ctx); err != nil {
 		appLog.Error("metrics server shutdown error", slog.String("error", err.Error()))
 	}
-	if debugServer != nil {
+	for _, debugServer := range debugServers {
 		if err := debugServer.Shutdown(ctx); err != nil {
-			appLog.Error("debug server shutdown error", slog.String("error", err.Error()))
+			appLog.Error("debug server shutdown error",
+				slog.String("addr", debugServer.Addr),
+				slog.String("error", err.Error()))
 		}
 	}
 
 	appLog.Info("llm-prober stopped")
+}
+
+// debugAddrs expands the configured debug address into the addresses to bind.
+//
+// "localhost" becomes both loopback families. The runtime image maps the name to
+// 127.0.0.1 and ::1 alike, and a client is free to pick either — busybox wget,
+// which is what is available in the container, picks ::1. Binding only one of
+// them answers "connection refused" to a client that chose the other, which
+// reads like the endpoint is disabled rather than like an address mismatch.
+//
+// An explicit IP literal is bound exactly as given: that is a deliberate choice
+// and should not be widened.
+func debugAddrs(addr string) []string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil
+	}
+	if host == "localhost" {
+		return []string{
+			net.JoinHostPort("127.0.0.1", port),
+			net.JoinHostPort("::1", port),
+		}
+	}
+	return []string{addr}
 }
 
 // isLoopbackAddr reports whether addr binds the loopback interface only.

--- a/cmd/llm-prober/main_test.go
+++ b/cmd/llm-prober/main_test.go
@@ -34,3 +34,47 @@ func TestIsLoopbackAddr(t *testing.T) {
 		}
 	}
 }
+
+func TestDebugAddrs(t *testing.T) {
+	tests := []struct {
+		addr string
+		want []string
+	}{
+		// "localhost" may resolve to either family, so bind both.
+		{"localhost:9091", []string{"127.0.0.1:9091", "[::1]:9091"}},
+		// An explicit literal is a deliberate choice; bind exactly it.
+		{"127.0.0.1:9091", []string{"127.0.0.1:9091"}},
+		{"[::1]:9091", []string{"[::1]:9091"}},
+		// Unparseable yields nothing to bind.
+		{"garbage", nil},
+		{"", nil},
+	}
+
+	for _, tt := range tests {
+		got := debugAddrs(tt.addr)
+		if len(got) != len(tt.want) {
+			t.Errorf("debugAddrs(%q) = %v, want %v", tt.addr, got, tt.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tt.want[i] {
+				t.Errorf("debugAddrs(%q)[%d] = %q, want %q", tt.addr, i, got[i], tt.want[i])
+			}
+		}
+	}
+}
+
+// Every address debugAddrs produces must still pass the loopback guard, so the
+// expansion cannot widen what the guard admitted.
+func TestDebugAddrsStayLoopback(t *testing.T) {
+	for _, addr := range []string{"localhost:9091", "127.0.0.1:9091", "[::1]:9091"} {
+		if !isLoopbackAddr(addr) {
+			t.Fatalf("test input %q is not loopback", addr)
+		}
+		for _, expanded := range debugAddrs(addr) {
+			if !isLoopbackAddr(expanded) {
+				t.Errorf("debugAddrs(%q) produced non-loopback address %q", addr, expanded)
+			}
+		}
+	}
+}

--- a/docs/llm-prober-state.md
+++ b/docs/llm-prober-state.md
@@ -104,7 +104,7 @@ ignored, never deleted.
 | `-state-db` | `LLM_PROBER_STATE_DB` | `/var/lib/llm-prober/state.db` (set in the image) | Database path; empty disables persistence |
 | `-state-flush-interval` | — | `5m` | How often pending timestamps are coalesced |
 | `-dump-state` | — | — | Print a **stopped** prober's database as JSON and exit |
-| `-debug-listen` | — | `127.0.0.1:9091` | Loopback address serving `/debug/state`; empty disables it |
+| `-debug-listen` | — | `localhost:9091` | Loopback address serving `/debug/state`; empty disables it |
 
 To read a **running** prober, use the `/debug/state` endpoint. bbolt holds an
 exclusive lock on the file for as long as the prober has it open, and a
@@ -131,6 +131,13 @@ reach it at all.
 or `localhost`. Anything else, including `:9091` and `0.0.0.0:9091`, is refused
 with a warning and leaves the endpoint switched off, so the isolation cannot be
 widened by a flag change alone.
+
+`localhost` binds **both** loopback families, because the runtime image maps the
+name to `127.0.0.1` and `::1` alike and a client may pick either — the busybox
+`wget` in the container picks `::1`. Binding one family only would answer
+"connection refused" to a client that chose the other, which reads like the
+endpoint is disabled rather than like an address mismatch. An explicit IP
+literal is bound exactly as given.
 
 `-dump-state` is for a prober that is stopped, or for a copy of its volume. Run
 against a running prober it fails with a message pointing at the endpoint rather


### PR DESCRIPTION
Follow-up to #106, found while verifying the live cluster after the rollout.

## The bug

The documented way to read a running prober does not work in the deployed container:

```
$ kubectl exec llm-prober-0 -n enchanted-proxy -- wget -O- http://localhost:9091/debug/state
Connecting to localhost:9091 ([::1]:9091)
wget: can't connect to remote host: Connection refused
```

The debug server binds `127.0.0.1` only. The runtime image maps `localhost` to **both** families:

```
$ kubectl exec llm-prober-0 -n enchanted-proxy -- cat /etc/hosts | grep localhost
127.0.0.1	localhost
::1	localhost ip6-localhost ip6-loopback
```

and the busybox `wget` that ships in the image picks `::1`. Using the IPv4 literal works, so the endpoint itself was fine — only unreachable by the name an operator would naturally type.

The failure mode is what makes this worth fixing rather than just re-documenting: a bare `connection refused` reads like the endpoint is disabled or the flag is misconfigured, not like an address-family mismatch. That is a bad way for a debugging tool to fail during an incident, which is exactly when it gets used.

## The fix

The default becomes `localhost:9091`, expanded into a listener on each loopback family, so the endpoint answers whichever address a client resolves to. An explicit IP literal is still bound exactly as given — that is a deliberate choice and should not be silently widened.

A family that fails to bind (a host without IPv6, say) is logged and skipped rather than fatal: one address is enough to serve the endpoint, and losing it entirely must still not stop probing.

## Exposure is unchanged

The loopback guard from #106 still applies to the flag value, and the expansion cannot widen it — every address it produces is itself loopback, asserted by a test against that same guard. `:9091` and `0.0.0.0:9091` remain refused.

## Verification

In the real image, all three now reach it, where `localhost` previously did not:

```
debug server listening addr=127.0.0.1:9091
debug server listening addr=[::1]:9091
--- wget localhost:9091 (busybox picks ::1) ---
Connecting to localhost:9091 ([::1]:9091)
writing to stdout          <- was "connection refused"
--- wget 127.0.0.1:9091 --- OK
--- wget [::1]:9091 ---     OK
```

Table tests cover the expansion and the loopback invariant. Full suite green under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The debug listener now defaults to `localhost:9091`.
  - `localhost` supports both IPv4 and IPv6 loopback connections.
  - Explicit IP addresses continue to bind only to the specified address.
  - Debug-server errors now identify the address that failed.

- **Documentation**
  - Updated the debug listener documentation to describe the new default and address-binding behavior.

- **Bug Fixes**
  - Improved handling and shutdown of multiple loopback listeners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->